### PR TITLE
fix: Windows build - platform-specific process management + filename fix

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -62,8 +61,7 @@ func removePID(path string) error {
 }
 
 func isProcessAlive(pid int) bool {
-	err := syscall.Kill(pid, 0)
-	return err == nil
+	return checkProcessAlive(pid)
 }
 
 func processUptime(pidPath string) (time.Duration, error) {
@@ -199,7 +197,7 @@ func runStart(port int, dbURI string, autoMigrate, mcpEnabled, noDB bool) error 
 	daemon := osExec.Command(execPath, serveArgs...)
 	daemon.Stdout = logFile
 	daemon.Stderr = logFile
-	daemon.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	setDaemonSysProcAttr(daemon)
 	// Inherit environment
 	daemon.Env = os.Environ()
 
@@ -280,8 +278,8 @@ func runStop() error {
 
 	// Send SIGTERM
 	fmt.Printf("Stopping MDEMG server (pid=%d)...\n", pid)
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("send SIGTERM: %w", err)
+	if err := terminateProcess(pid); err != nil {
+		return fmt.Errorf("terminate process: %w", err)
 	}
 
 	// Poll for process exit (up to 30s)
@@ -297,8 +295,8 @@ func runStop() error {
 	}
 
 	// Force kill
-	fmt.Println("Warning: graceful shutdown timed out, sending SIGKILL")
-	_ = syscall.Kill(pid, syscall.SIGKILL)
+	fmt.Println("Warning: graceful shutdown timed out, force killing process")
+	_ = forceKillProcess(pid)
 	time.Sleep(1 * time.Second)
 	_ = removePID(pidPath)
 	fmt.Println("MDEMG server killed")

--- a/internal/cli/executor_local.go
+++ b/internal/cli/executor_local.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	osExec "os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (e *LocalExecutor) StartDaemon(serveArgs []string, extraEnv ...string) (int
 	daemon := osExec.Command(execPath, serveArgs...)
 	daemon.Stdout = logFile
 	daemon.Stderr = logFile
-	daemon.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	setDaemonSysProcAttr(daemon)
 	daemon.Env = append(os.Environ(), extraEnv...)
 
 	if startErr := daemon.Start(); startErr != nil {
@@ -65,8 +64,8 @@ func (e *LocalExecutor) StartDaemon(serveArgs []string, extraEnv ...string) (int
 
 // StopDaemon sends SIGTERM, polls for exit (30s), then SIGKILL.
 func (e *LocalExecutor) StopDaemon(pid int) error {
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("SIGTERM: %w", err)
+	if err := terminateProcess(pid); err != nil {
+		return fmt.Errorf("terminate process: %w", err)
 	}
 
 	deadline := time.Now().Add(30 * time.Second)
@@ -78,7 +77,7 @@ func (e *LocalExecutor) StopDaemon(pid int) error {
 	}
 
 	// Force kill after timeout
-	_ = syscall.Kill(pid, syscall.SIGKILL)
+	_ = forceKillProcess(pid)
 	time.Sleep(1 * time.Second)
 	return nil
 }

--- a/internal/cli/process_unix.go
+++ b/internal/cli/process_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package cli
+
+import (
+	osExec "os/exec"
+	"syscall"
+)
+
+// checkProcessAlive uses kill -0 to test if a PID exists.
+func checkProcessAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+// setDaemonSysProcAttr configures the command for background daemon execution.
+func setDaemonSysProcAttr(cmd *osExec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// terminateProcess sends SIGTERM to gracefully stop a process.
+func terminateProcess(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}
+
+// forceKillProcess sends SIGKILL to forcefully stop a process.
+func forceKillProcess(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/internal/cli/process_windows.go
+++ b/internal/cli/process_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	osExec "os/exec"
+	"strings"
+	"syscall"
+)
+
+// checkProcessAlive queries the Windows task list to check if a PID exists.
+func checkProcessAlive(pid int) bool {
+	cmd := osExec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/FO", "CSV", "/NH")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return !strings.Contains(string(out), "INFO: No tasks")
+}
+
+// setDaemonSysProcAttr configures the command for background execution on Windows.
+func setDaemonSysProcAttr(cmd *osExec.Cmd) {
+	const createNewProcessGroup = 0x00000200
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: createNewProcessGroup,
+	}
+}
+
+// terminateProcess kills a process on Windows (no SIGTERM equivalent).
+func terminateProcess(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	return p.Kill()
+}
+
+// forceKillProcess forcefully kills a process (same as terminate on Windows).
+func forceKillProcess(pid int) error {
+	return terminateProcess(pid)
+}


### PR DESCRIPTION
## Summary
- Renames `<lang>_parser_lst.md` to `lang_parser_lst.md` (angle brackets illegal on Windows paths)
- Extracts Unix-only syscalls (`Kill`, `Setsid`) into `process_unix.go` / `process_windows.go` with build tags
- Windows uses `tasklist` for process checks, `CREATE_NEW_PROCESS_GROUP` for daemon, `os.Process.Kill()` for termination

## Context
The v0.2.10 release workflow failed twice:
1. First: `git checkout` failed because `<lang>_parser_lst.md` has Windows-illegal characters
2. Second: `go build` failed because `syscall.Kill` and `SysProcAttr.Setsid` are undefined on Windows

## Test plan
- [x] Local `go build ./...` passes
- [x] `golangci-lint run ./internal/cli/...` — 0 issues
- [x] `go test ./internal/cli/...` — passes
- [x] No remaining `syscall.Kill` or `Setsid` usage in daemon.go or executor_local.go
- [ ] Windows CI build succeeds after merge + retag