### PR TITLE
feat: add PHP language parser with Laravel and WordPress support

### DIFF
--- a/docs/lang-parser/lang-parse-spec/upts/README.md
+++ b/docs/lang-parser/lang-parse-spec/upts/README.md
@@ -28,7 +28,7 @@ UPTS provides:
 
 ## Current Status
 
-**27 UPTS-validated parsers** — all pass via `go test`:
+**28 UPTS-validated parsers** — all pass via `go test`:
 
 | Language | Spec | Fixture | Parser |
 |----------|------|---------|--------|
@@ -70,7 +70,7 @@ upts/
 ├── schema/
 │   └── upts.schema.json             # JSON Schema (canonical definition)
 │
-├── specs/                            # 27 UPTS spec files
+├── specs/                            # 28 UPTS spec files
 │   ├── go.upts.json
 │   ├── rust.upts.json
 │   ├── python.upts.json
@@ -99,7 +99,7 @@ upts/
 │   ├── lua.upts.json
 │   └── scraper_markdown.upts.json
 │
-├── fixtures/                         # 27 test fixture files
+├── fixtures/                         # 28 test fixture files
 │   ├── go_test_fixture.go
 │   ├── rust_test_fixture.rs
 │   ├── python_test_fixture.py
@@ -129,7 +129,7 @@ The primary validation method is the Go-native test harness in the parser direct
 ### 1. Run All UPTS Tests (Go-Native — Recommended)
 
 ```bash
-# All 27 UPTS-validated parsers
+# All 28 UPTS-validated parsers
 go test ./cmd/ingest-codebase/languages/ -run TestUPTS -v
 
 # Single language

--- a/docs/lang-parser/lang-parse-spec/upts/README.md
+++ b/docs/lang-parser/lang-parse-spec/upts/README.md
@@ -38,6 +38,7 @@ UPTS provides:
 | TypeScript | [`typescript.upts.json`](specs/typescript.upts.json) | [`typescript_test_fixture.ts`](fixtures/typescript_test_fixture.ts) | [`typescript_parser.go`](../../../../cmd/ingest-codebase/languages/typescript_parser.go) |
 | Java | [`java.upts.json`](specs/java.upts.json) | [`java_test_fixture.java`](fixtures/java_test_fixture.java) | [`java_parser.go`](../../../../cmd/ingest-codebase/languages/java_parser.go) |
 | C# | [`csharp.upts.json`](specs/csharp.upts.json) | [`csharp_test_fixture.cs`](fixtures/csharp_test_fixture.cs) | [`csharp_parser.go`](../../../../cmd/ingest-codebase/languages/csharp_parser.go) |
+| PHP | [`php.upts.json`](specs/php.upts.json) | [`php_test_fixture.php`](fixtures/php_test_fixture.php) | [`php_parser.go`](../../../../internal/languages/php_parser.go) |
 | Kotlin | [`kotlin.upts.json`](specs/kotlin.upts.json) | [`kotlin_test_fixture.kt`](fixtures/kotlin_test_fixture.kt) | [`kotlin_parser.go`](../../../../cmd/ingest-codebase/languages/kotlin_parser.go) |
 | C++ | [`cpp.upts.json`](specs/cpp.upts.json) | [`cpp_test_fixture.cpp`](fixtures/cpp_test_fixture.cpp) | [`cpp_parser.go`](../../../../cmd/ingest-codebase/languages/cpp_parser.go) |
 | C | [`c.upts.json`](specs/c.upts.json) | [`c_test_fixture.c`](fixtures/c_test_fixture.c) | [`c_parser.go`](../../../../cmd/ingest-codebase/languages/c_parser.go) |

--- a/docs/lang-parser/lang-parse-spec/upts/README.md
+++ b/docs/lang-parser/lang-parse-spec/upts/README.md
@@ -77,6 +77,7 @@ upts/
 │   ├── typescript.upts.json
 │   ├── java.upts.json
 │   ├── csharp.upts.json
+│   ├── php.upts.json
 │   ├── kotlin.upts.json
 │   ├── cpp.upts.json
 │   ├── c.upts.json

--- a/docs/lang-parser/lang-parse-spec/upts/fixtures/php_test_fixture.php
+++ b/docs/lang-parser/lang-parse-spec/upts/fixtures/php_test_fixture.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+// Top-level constant
+const MAX_RETRIES = 3;
+
+// WordPress-style define constant
+define('PLUGIN_VERSION', '2.1.0');
+
+/**
+ * Cacheable interface for cache-aware services.
+ */
+interface Cacheable
+{
+    public function getCacheKey(): string;
+
+    public function getCacheTtl(): int;
+}
+
+/**
+ * Trait for slug generation.
+ */
+trait HasSlug
+{
+    public function generateSlug(string $value): string
+    {
+        return strtolower(str_replace(' ', '-', $value));
+    }
+
+    protected function slugExists(string $slug): bool
+    {
+        return false;
+    }
+}
+
+/**
+ * Status enum for user accounts.
+ */
+enum UserStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Suspended = 'suspended';
+}
+
+/**
+ * User service handling user operations.
+ */
+class UserService implements Cacheable
+{
+    use HasSlug;
+
+    public const DEFAULT_ROLE = 'member';
+    protected const CACHE_PREFIX = 'user_svc';
+    private const MAX_BATCH_SIZE = 100;
+
+    // BUG-FIX TEST: multi-line array constant
+    private const ALLOWED_TYPES = [
+        'admin',
+        'editor',
+        'viewer',
+    ];
+
+    // BUG-FIX TEST: constant with trailing comment
+    private const THROTTLE_SECONDS = 900; // 15 minutes
+
+    public string $serviceName = 'UserService';
+    protected int $timeout = 30;
+    private readonly string $apiKey;
+
+    // BUG-FIX TEST: constructor emitted as method + promoted property extraction
+    public function __construct(
+        private readonly UserRepository $repository,
+    ) {
+        $this->apiKey = config('services.user.key');
+    }
+
+    public function findById(int $id): ?User
+    {
+        return $this->repository->find($id);
+    }
+
+    public function createUser(array $data): User
+    {
+        $slug = $this->generateSlug($data['name']);
+        return $this->repository->create(array_merge($data, ['slug' => $slug]));
+    }
+
+    protected function validateData(array $data): bool
+    {
+        return isset($data['name']) && isset($data['email']);
+    }
+
+    private function hashPassword(string $password): string
+    {
+        return password_hash($password, PASSWORD_ARGON2ID);
+    }
+
+    public static function getVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    // BUG-FIX TEST: reversed static modifier order (Beaver Builder style)
+    static public function getInstance(): self
+    {
+        return new self(new UserRepository());
+    }
+
+    // BUG-FIX TEST: reversed static field modifier
+    static protected int $instanceCount = 0;
+
+    // BUG-FIX TEST: reference-return method
+    public function &getReference(): array
+    {
+        return $this->data;
+    }
+
+    public function getCacheKey(): string
+    {
+        return self::CACHE_PREFIX . ':' . $this->serviceName;
+    }
+
+    public function getCacheTtl(): int
+    {
+        return 3600;
+    }
+
+    // BUG-FIX TEST: heredoc should NOT produce false-positive constants
+    public function getScript(): string
+    {
+        return <<<'JS'
+            const el = document.querySelector('.widget');
+            const buttons = el.querySelectorAll('button');
+        JS;
+    }
+}
+
+/**
+ * Abstract base controller.
+ */
+abstract class BaseController
+{
+    abstract public function index(): array;
+
+    public function respond(mixed $data, int $status = 200): array
+    {
+        return ['data' => $data, 'status' => $status];
+    }
+}
+
+/**
+ * BUG-FIX TEST: bare methods without visibility (WordPress/legacy style)
+ */
+class LegacyWidget
+{
+    function render()
+    {
+        return '<div>widget</div>';
+    }
+
+    function update($data)
+    {
+        return $data;
+    }
+}
+
+/**
+ * BUG-FIX TEST: readonly class (PHP 8.2)
+ */
+readonly class ValueObject
+{
+    public function __construct(
+        public string $name,
+        public int $value,
+    ) {}
+}
+
+/**
+ * BUG-FIX TEST: single-line constructor with promoted properties
+ */
+class Notification
+{
+    public function __construct(public string $message, public int $priority = 0) {}
+}
+
+/**
+ * Standalone helper function.
+ */
+function formatCurrency(float $amount, string $currency = 'USD'): string
+{
+    return number_format($amount, 2) . ' ' . $currency;
+}
+
+/**
+ * BUG-FIX TEST: indented guarded function
+ */
+if (! function_exists('calculateDiscount')) {
+    function calculateDiscount(float $price, float $percent): float
+    {
+        return $price * (1 - $percent / 100);
+    }
+}
+
+// WordPress-style hooks
+add_action('init', 'custom_post_type_init');
+add_filter('the_content', 'filter_content_output');

--- a/docs/lang-parser/lang-parse-spec/upts/schema/upts.schema.json
+++ b/docs/lang-parser/lang-parse-spec/upts/schema/upts.schema.json
@@ -38,6 +38,7 @@
         "makefile",
         "markdown",
         "openapi",
+        "php",
         "protobuf",
         "python",
         "rust",

--- a/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
+++ b/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
@@ -439,6 +439,18 @@
         "pattern": "P2_FUNCTION",
         "_regression": "indented guarded function"
       }
+    ],
+    "excluded": [
+      {
+        "name": "el",
+        "type": "constant",
+        "reason": "JS const inside heredoc string — must not be parsed as PHP constant"
+      },
+      {
+        "name": "buttons",
+        "type": "constant",
+        "reason": "JS const inside heredoc string — must not be parsed as PHP constant"
+      }
     ]
   },
   "patterns_covered": [

--- a/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
+++ b/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
@@ -1,12 +1,22 @@
 {
   "upts_version": "1.0.0",
   "language": "php",
-  "variants": [".php"],
+  "variants": [
+    ".php"
+  ],
   "metadata": {
     "author": "diegovogel",
     "created": "2026-04-06",
-    "description": "PHP parser — classes, interfaces, traits, enums, functions, constants, namespaces, fields, methods. Includes regression tests for: heredoc false-positives, multi-line array constants, trailing-comment constants, bare methods, reversed static modifiers, readonly class, reference-return functions, indented guarded functions, constructor emission, promoted properties.",
-    "parser_status": "functional"
+    "updated": "2026-04-07",
+    "description": "PHP parser \u2014 classes, interfaces, traits, enums, functions, constants, namespaces, fields, methods. Includes regression tests for: heredoc false-positives, multi-line array constants, trailing-comment constants, bare methods, reversed static modifiers, readonly class, reference-return functions, indented guarded functions, constructor emission, promoted properties.",
+    "parser_status": "functional",
+    "tags": [
+      "canonical",
+      "oop",
+      "php8",
+      "laravel",
+      "wordpress"
+    ]
   },
   "config": {
     "line_tolerance": 2,
@@ -162,8 +172,7 @@
         "line": 64,
         "exported": false,
         "parent": "UserService",
-        "pattern": "P1_CONSTANT",
-        "_regression": "multi-line array constant"
+        "pattern": "P1_CONSTANT"
       },
       {
         "name": "THROTTLE_SECONDS",
@@ -171,8 +180,7 @@
         "line": 71,
         "exported": false,
         "parent": "UserService",
-        "pattern": "P1_CONSTANT",
-        "_regression": "constant with trailing comment"
+        "pattern": "P1_CONSTANT"
       },
       {
         "name": "serviceName",
@@ -204,8 +212,7 @@
         "line": 78,
         "exported": true,
         "parent": "UserService",
-        "pattern": "P6_METHOD",
-        "_regression": "constructor emitted as method"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "repository",
@@ -213,8 +220,7 @@
         "line": 79,
         "exported": false,
         "parent": "UserService",
-        "pattern": "P9_FIELD",
-        "_regression": "constructor promoted property"
+        "pattern": "P9_FIELD"
       },
       {
         "name": "findById",
@@ -262,8 +268,7 @@
         "line": 111,
         "exported": true,
         "parent": "UserService",
-        "pattern": "P6_METHOD",
-        "_regression": "reversed static modifier order"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "instanceCount",
@@ -271,8 +276,7 @@
         "line": 117,
         "exported": false,
         "parent": "UserService",
-        "pattern": "P9_FIELD",
-        "_regression": "reversed static field modifier"
+        "pattern": "P9_FIELD"
       },
       {
         "name": "getReference",
@@ -280,8 +284,7 @@
         "line": 120,
         "exported": true,
         "parent": "UserService",
-        "pattern": "P6_METHOD",
-        "_regression": "reference-return method"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "getCacheKey",
@@ -305,8 +308,7 @@
         "line": 136,
         "exported": true,
         "parent": "UserService",
-        "pattern": "P6_METHOD",
-        "_regression": "heredoc should not produce false-positive constants"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "BaseController",
@@ -336,8 +338,7 @@
         "type": "class",
         "line": 161,
         "exported": true,
-        "pattern": "P3_CLASS_STRUCT",
-        "_regression": "bare methods without visibility"
+        "pattern": "P3_CLASS_STRUCT"
       },
       {
         "name": "render",
@@ -345,8 +346,7 @@
         "line": 163,
         "exported": true,
         "parent": "LegacyWidget",
-        "pattern": "P6_METHOD",
-        "_regression": "bare method defaults to public"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "update",
@@ -354,16 +354,14 @@
         "line": 168,
         "exported": true,
         "parent": "LegacyWidget",
-        "pattern": "P6_METHOD",
-        "_regression": "bare method defaults to public"
+        "pattern": "P6_METHOD"
       },
       {
         "name": "ValueObject",
         "type": "class",
         "line": 177,
         "exported": true,
-        "pattern": "P3_CLASS_STRUCT",
-        "_regression": "readonly class (PHP 8.2)"
+        "pattern": "P3_CLASS_STRUCT"
       },
       {
         "name": "__construct",
@@ -379,8 +377,7 @@
         "line": 180,
         "exported": true,
         "parent": "ValueObject",
-        "pattern": "P9_FIELD",
-        "_regression": "multi-line constructor promoted property"
+        "pattern": "P9_FIELD"
       },
       {
         "name": "value",
@@ -395,8 +392,7 @@
         "type": "class",
         "line": 188,
         "exported": true,
-        "pattern": "P3_CLASS_STRUCT",
-        "_regression": "single-line constructor promoted properties"
+        "pattern": "P3_CLASS_STRUCT"
       },
       {
         "name": "__construct",
@@ -412,8 +408,7 @@
         "line": 190,
         "exported": true,
         "parent": "Notification",
-        "pattern": "P9_FIELD",
-        "_regression": "single-line constructor promoted property"
+        "pattern": "P9_FIELD"
       },
       {
         "name": "priority",
@@ -421,8 +416,7 @@
         "line": 190,
         "exported": true,
         "parent": "Notification",
-        "pattern": "P9_FIELD",
-        "_regression": "single-line constructor promoted property"
+        "pattern": "P9_FIELD"
       },
       {
         "name": "formatCurrency",
@@ -436,20 +430,129 @@
         "type": "function",
         "line": 205,
         "exported": true,
-        "pattern": "P2_FUNCTION",
-        "_regression": "indented guarded function"
+        "pattern": "P2_FUNCTION"
       }
     ],
     "excluded": [
       {
         "name": "el",
-        "type": "constant",
-        "reason": "JS const inside heredoc string — must not be parsed as PHP constant"
+        "reason": "JS const inside heredoc string \u2014 must not be parsed as PHP constant"
       },
       {
         "name": "buttons",
-        "type": "constant",
-        "reason": "JS const inside heredoc string — must not be parsed as PHP constant"
+        "reason": "JS const inside heredoc string \u2014 must not be parsed as PHP constant"
+      }
+    ],
+    "relationships": [
+      {
+        "source": "Cacheable",
+        "relation": "DEFINES_METHOD",
+        "target": "getCacheKey"
+      },
+      {
+        "source": "Cacheable",
+        "relation": "DEFINES_METHOD",
+        "target": "getCacheTtl"
+      },
+      {
+        "source": "HasSlug",
+        "relation": "DEFINES_METHOD",
+        "target": "generateSlug"
+      },
+      {
+        "source": "HasSlug",
+        "relation": "DEFINES_METHOD",
+        "target": "slugExists"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "__construct"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "findById"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "createUser"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "validateData"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "hashPassword"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getVersion"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getInstance"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getReference"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getCacheKey"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getCacheTtl"
+      },
+      {
+        "source": "UserService",
+        "relation": "DEFINES_METHOD",
+        "target": "getScript"
+      },
+      {
+        "source": "UserService",
+        "relation": "IMPLEMENTS",
+        "target": "Cacheable"
+      },
+      {
+        "source": "BaseController",
+        "relation": "DEFINES_METHOD",
+        "target": "index"
+      },
+      {
+        "source": "BaseController",
+        "relation": "DEFINES_METHOD",
+        "target": "respond"
+      },
+      {
+        "source": "LegacyWidget",
+        "relation": "DEFINES_METHOD",
+        "target": "render"
+      },
+      {
+        "source": "LegacyWidget",
+        "relation": "DEFINES_METHOD",
+        "target": "update"
+      },
+      {
+        "source": "ValueObject",
+        "relation": "DEFINES_METHOD",
+        "target": "__construct"
+      },
+      {
+        "source": "Notification",
+        "relation": "DEFINES_METHOD",
+        "target": "__construct"
       }
     ]
   },

--- a/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
+++ b/docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json
@@ -1,0 +1,455 @@
+{
+  "upts_version": "1.0.0",
+  "language": "php",
+  "variants": [".php"],
+  "metadata": {
+    "author": "diegovogel",
+    "created": "2026-04-06",
+    "description": "PHP parser — classes, interfaces, traits, enums, functions, constants, namespaces, fields, methods. Includes regression tests for: heredoc false-positives, multi-line array constants, trailing-comment constants, bare methods, reversed static modifiers, readonly class, reference-return functions, indented guarded functions, constructor emission, promoted properties.",
+    "parser_status": "functional"
+  },
+  "config": {
+    "line_tolerance": 2,
+    "require_all_symbols": true,
+    "allow_extra_symbols": true,
+    "validate_parent": true,
+    "validate_signature": false,
+    "validate_value": false
+  },
+  "fixture": {
+    "type": "file",
+    "path": "../fixtures/php_test_fixture.php",
+    "sha256": "26f64532b73f6c317ad5a1af85c14f199ad9a37982f4c01da0e9046fa5dde03b"
+  },
+  "expected": {
+    "symbol_count": {
+      "min": 48,
+      "max": 55
+    },
+    "symbols": [
+      {
+        "name": "App\\Services",
+        "type": "namespace",
+        "line": 5,
+        "exported": true,
+        "pattern": "P5_NAMESPACE"
+      },
+      {
+        "name": "MAX_RETRIES",
+        "type": "constant",
+        "line": 11,
+        "exported": true,
+        "pattern": "P1_CONSTANT"
+      },
+      {
+        "name": "PLUGIN_VERSION",
+        "type": "constant",
+        "line": 14,
+        "exported": true,
+        "pattern": "P1_CONSTANT"
+      },
+      {
+        "name": "Cacheable",
+        "type": "interface",
+        "line": 19,
+        "exported": true,
+        "pattern": "P4_INTERFACE_TRAIT"
+      },
+      {
+        "name": "getCacheKey",
+        "type": "method",
+        "line": 21,
+        "exported": true,
+        "parent": "Cacheable",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "getCacheTtl",
+        "type": "method",
+        "line": 23,
+        "exported": true,
+        "parent": "Cacheable",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "HasSlug",
+        "type": "trait",
+        "line": 29,
+        "exported": true,
+        "pattern": "P4_INTERFACE_TRAIT"
+      },
+      {
+        "name": "generateSlug",
+        "type": "method",
+        "line": 31,
+        "exported": true,
+        "parent": "HasSlug",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "slugExists",
+        "type": "method",
+        "line": 36,
+        "exported": false,
+        "parent": "HasSlug",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "UserStatus",
+        "type": "enum",
+        "line": 45,
+        "exported": true,
+        "pattern": "P5_ENUM"
+      },
+      {
+        "name": "Active",
+        "type": "enum_value",
+        "line": 47,
+        "exported": true,
+        "parent": "UserStatus",
+        "pattern": "P5_ENUM_VALUE"
+      },
+      {
+        "name": "Inactive",
+        "type": "enum_value",
+        "line": 48,
+        "exported": true,
+        "parent": "UserStatus",
+        "pattern": "P5_ENUM_VALUE"
+      },
+      {
+        "name": "Suspended",
+        "type": "enum_value",
+        "line": 49,
+        "exported": true,
+        "parent": "UserStatus",
+        "pattern": "P5_ENUM_VALUE"
+      },
+      {
+        "name": "UserService",
+        "type": "class",
+        "line": 55,
+        "exported": true,
+        "pattern": "P3_CLASS_STRUCT"
+      },
+      {
+        "name": "DEFAULT_ROLE",
+        "type": "constant",
+        "line": 59,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P1_CONSTANT"
+      },
+      {
+        "name": "CACHE_PREFIX",
+        "type": "constant",
+        "line": 60,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P1_CONSTANT"
+      },
+      {
+        "name": "MAX_BATCH_SIZE",
+        "type": "constant",
+        "line": 61,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P1_CONSTANT"
+      },
+      {
+        "name": "ALLOWED_TYPES",
+        "type": "constant",
+        "line": 64,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P1_CONSTANT",
+        "_regression": "multi-line array constant"
+      },
+      {
+        "name": "THROTTLE_SECONDS",
+        "type": "constant",
+        "line": 71,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P1_CONSTANT",
+        "_regression": "constant with trailing comment"
+      },
+      {
+        "name": "serviceName",
+        "type": "field",
+        "line": 73,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P9_FIELD"
+      },
+      {
+        "name": "timeout",
+        "type": "field",
+        "line": 74,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P9_FIELD"
+      },
+      {
+        "name": "apiKey",
+        "type": "field",
+        "line": 75,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P9_FIELD"
+      },
+      {
+        "name": "__construct",
+        "type": "method",
+        "line": 78,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD",
+        "_regression": "constructor emitted as method"
+      },
+      {
+        "name": "repository",
+        "type": "field",
+        "line": 79,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P9_FIELD",
+        "_regression": "constructor promoted property"
+      },
+      {
+        "name": "findById",
+        "type": "method",
+        "line": 84,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "createUser",
+        "type": "method",
+        "line": 89,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "validateData",
+        "type": "method",
+        "line": 95,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "hashPassword",
+        "type": "method",
+        "line": 100,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "getVersion",
+        "type": "method",
+        "line": 105,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "getInstance",
+        "type": "method",
+        "line": 111,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD",
+        "_regression": "reversed static modifier order"
+      },
+      {
+        "name": "instanceCount",
+        "type": "field",
+        "line": 117,
+        "exported": false,
+        "parent": "UserService",
+        "pattern": "P9_FIELD",
+        "_regression": "reversed static field modifier"
+      },
+      {
+        "name": "getReference",
+        "type": "method",
+        "line": 120,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD",
+        "_regression": "reference-return method"
+      },
+      {
+        "name": "getCacheKey",
+        "type": "method",
+        "line": 125,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "getCacheTtl",
+        "type": "method",
+        "line": 130,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "getScript",
+        "type": "method",
+        "line": 136,
+        "exported": true,
+        "parent": "UserService",
+        "pattern": "P6_METHOD",
+        "_regression": "heredoc should not produce false-positive constants"
+      },
+      {
+        "name": "BaseController",
+        "type": "class",
+        "line": 148,
+        "exported": true,
+        "pattern": "P3_CLASS_STRUCT"
+      },
+      {
+        "name": "index",
+        "type": "method",
+        "line": 150,
+        "exported": true,
+        "parent": "BaseController",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "respond",
+        "type": "method",
+        "line": 152,
+        "exported": true,
+        "parent": "BaseController",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "LegacyWidget",
+        "type": "class",
+        "line": 161,
+        "exported": true,
+        "pattern": "P3_CLASS_STRUCT",
+        "_regression": "bare methods without visibility"
+      },
+      {
+        "name": "render",
+        "type": "method",
+        "line": 163,
+        "exported": true,
+        "parent": "LegacyWidget",
+        "pattern": "P6_METHOD",
+        "_regression": "bare method defaults to public"
+      },
+      {
+        "name": "update",
+        "type": "method",
+        "line": 168,
+        "exported": true,
+        "parent": "LegacyWidget",
+        "pattern": "P6_METHOD",
+        "_regression": "bare method defaults to public"
+      },
+      {
+        "name": "ValueObject",
+        "type": "class",
+        "line": 177,
+        "exported": true,
+        "pattern": "P3_CLASS_STRUCT",
+        "_regression": "readonly class (PHP 8.2)"
+      },
+      {
+        "name": "__construct",
+        "type": "method",
+        "line": 179,
+        "exported": true,
+        "parent": "ValueObject",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "name",
+        "type": "field",
+        "line": 180,
+        "exported": true,
+        "parent": "ValueObject",
+        "pattern": "P9_FIELD",
+        "_regression": "multi-line constructor promoted property"
+      },
+      {
+        "name": "value",
+        "type": "field",
+        "line": 181,
+        "exported": true,
+        "parent": "ValueObject",
+        "pattern": "P9_FIELD"
+      },
+      {
+        "name": "Notification",
+        "type": "class",
+        "line": 188,
+        "exported": true,
+        "pattern": "P3_CLASS_STRUCT",
+        "_regression": "single-line constructor promoted properties"
+      },
+      {
+        "name": "__construct",
+        "type": "method",
+        "line": 190,
+        "exported": true,
+        "parent": "Notification",
+        "pattern": "P6_METHOD"
+      },
+      {
+        "name": "message",
+        "type": "field",
+        "line": 190,
+        "exported": true,
+        "parent": "Notification",
+        "pattern": "P9_FIELD",
+        "_regression": "single-line constructor promoted property"
+      },
+      {
+        "name": "priority",
+        "type": "field",
+        "line": 190,
+        "exported": true,
+        "parent": "Notification",
+        "pattern": "P9_FIELD",
+        "_regression": "single-line constructor promoted property"
+      },
+      {
+        "name": "formatCurrency",
+        "type": "function",
+        "line": 196,
+        "exported": true,
+        "pattern": "P2_FUNCTION"
+      },
+      {
+        "name": "calculateDiscount",
+        "type": "function",
+        "line": 205,
+        "exported": true,
+        "pattern": "P2_FUNCTION",
+        "_regression": "indented guarded function"
+      }
+    ]
+  },
+  "patterns_covered": [
+    "P1_CONSTANT",
+    "P2_FUNCTION",
+    "P3_CLASS_STRUCT",
+    "P4_INTERFACE_TRAIT",
+    "P5_ENUM",
+    "P5_ENUM_VALUE",
+    "P5_NAMESPACE",
+    "P6_METHOD",
+    "P9_FIELD"
+  ]
+}

--- a/docs/specs/FRAMEWORK_GOVERNANCE.md
+++ b/docs/specs/FRAMEWORK_GOVERNANCE.md
@@ -17,7 +17,7 @@ Use this governance file as policy, `docs/development/UXTS_FRAMEWORK_MATRIX.md` 
 | UNTS | Universal Hash Test Specification | Hash verification registry, verify-now, revert | active |
 | UDTS | Universal DevSpace Test Specification | gRPC contract and integration tests | active |
 | UATS | Universal API Test Specification | HTTP acceptance contract tests | active (124 specs, CI-gated) |
-| UPTS | Universal Parser Test Specification | Parser contract conformance across languages | active (27 specs, CI-gated) |
+| UPTS | Universal Parser Test Specification | Parser contract conformance across languages | active (28 specs, CI-gated) |
 | UBTS | Universal Benchmark Test Specification | Throughput/latency/load regression testing | active (CI smoke, soft-fail) |
 | USTS | Universal Security Test Specification | Security behavior and hardening checks | pilot |
 | UAMS | Universal Auth Method Specification | Auth method contracts and conformance | spec-only (no runner/fixtures) |

--- a/internal/languages/README.md
+++ b/internal/languages/README.md
@@ -4,7 +4,7 @@ This directory contains modular language parsers for the MDEMG codebase ingestio
 
 ## Supported Languages
 
-27 parsers, 27 with UPTS validation specs (100%).
+28 parsers, 28 with UPTS validation specs (100%).
 
 | Language | File | Extensions | UPTS |
 |----------|------|------------|------|
@@ -42,7 +42,7 @@ This directory contains modular language parsers for the MDEMG codebase ingestio
 Each parser's symbol extraction is validated against a [UPTS (Universal Parser Test Specification)](../../../docs/lang-parser/lang-parse-spec/upts/README.md) spec file. The Go-native test harness loads the spec, parses the associated fixture file through the parser, and asserts that all expected symbols are found with correct name, type, line number, and export status.
 
 ```bash
-# Run all 27 UPTS-validated parsers
+# Run all 28 UPTS-validated parsers
 go test ./cmd/ingest-codebase/languages/ -run TestUPTS -v
 
 # Run a single language

--- a/internal/languages/README.md
+++ b/internal/languages/README.md
@@ -14,6 +14,7 @@ This directory contains modular language parsers for the MDEMG codebase ingestio
 | TypeScript/JavaScript | [`typescript_parser.go`](typescript_parser.go) | `.ts`, `.tsx`, `.js`, `.jsx` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/typescript.upts.json) |
 | Java | [`java_parser.go`](java_parser.go) | `.java` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/java.upts.json) |
 | C# | [`csharp_parser.go`](csharp_parser.go) | `.cs` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/csharp.upts.json) |
+| PHP | [`php_parser.go`](php_parser.go) | `.php` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/php.upts.json) |
 | Kotlin | [`kotlin_parser.go`](kotlin_parser.go) | `.kt`, `.kts` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/kotlin.upts.json) |
 | C++ | [`cpp_parser.go`](cpp_parser.go) | `.cpp`, `.cxx`, `.cc`, `.hpp`, `.hxx`, `.h` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/cpp.upts.json) |
 | C | [`c_parser.go`](c_parser.go) | `.c`, `.h` | [Yes](../../../docs/lang-parser/lang-parse-spec/upts/specs/c.upts.json) |

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -30,9 +30,24 @@ func (p *PHPParser) IsTestFile(path string) bool {
 	name := filepath.Base(path)
 	inTestDir := strings.Contains(path, "/tests/") || strings.Contains(path, "/test/")
 	hasTestSuffix := strings.HasSuffix(name, "Test.php") || strings.HasSuffix(name, "_test.php")
-	// Require test directory for suffix-based detection to avoid false positives
-	// on production files like app/Models/Test.php
-	return inTestDir || (hasTestSuffix && !strings.Contains(path, "/app/"))
+	// In test directory — always a test file
+	if inTestDir {
+		return true
+	}
+	// Suffix heuristic: exclude known Laravel/WordPress production directories
+	// to avoid false positives on files like app/Models/Test.php
+	if hasTestSuffix {
+		prodDirs := []string{"/app/Models/", "/app/Http/", "/app/Providers/",
+			"/app/Services/", "/app/Actions/", "/app/Livewire/",
+			"/app/Nova/", "/wp-content/", "/wp-admin/", "/wp-includes/"}
+		for _, dir := range prodDirs {
+			if strings.Contains(path, dir) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func (p *PHPParser) ParseFile(root, path string, extractSymbols bool) ([]CodeElement, error) {

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -347,18 +347,23 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 			continue
 		}
 
-		// Top-level define() constant
-		if matches := definePattern.FindStringSubmatch(line); matches != nil {
-			symbols = append(symbols, Symbol{
-				Name:     matches[1],
-				Type:     "constant",
-				Value:    CleanValue(matches[2]),
-				RawValue: matches[2],
-				Line:     lineNum,
-				Exported: true,
-				Language: "php",
-			})
-			continue
+		// Track whether we're inside a function/method body
+		inFunctionBody := (currentType == "" && braceDepth > 0) || (currentType != "" && braceDepth > typeStartDepth+1)
+
+		// Top-level define() constant (skip if inside a function/method body)
+		if !inFunctionBody {
+			if matches := definePattern.FindStringSubmatch(line); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[1],
+					Type:     "constant",
+					Value:    CleanValue(matches[2]),
+					RawValue: matches[2],
+					Line:     lineNum,
+					Exported: true,
+					Language: "php",
+				})
+				continue
+			}
 		}
 
 		// Top-level const
@@ -587,17 +592,17 @@ func detectPHPFrameworkTags(relPath, content string) []string {
 }
 
 // detectPHPTypeKind determines whether a name is a class, interface, trait, or enum.
+// Note: regex is compiled per call because the pattern includes the dynamic type name.
+// This runs once per class/interface/trait/enum in the file (typically < 10 calls).
 func detectPHPTypeKind(content, name string) string {
-	interfaceRe := regexp.MustCompile(`(?m)^\s*interface\s+` + regexp.QuoteMeta(name))
-	if interfaceRe.MatchString(content) {
+	quotedName := regexp.QuoteMeta(name)
+	if regexp.MustCompile(`(?m)^\s*interface\s+` + quotedName).MatchString(content) {
 		return "interface"
 	}
-	traitRe := regexp.MustCompile(`(?m)^\s*trait\s+` + regexp.QuoteMeta(name))
-	if traitRe.MatchString(content) {
+	if regexp.MustCompile(`(?m)^\s*trait\s+` + quotedName).MatchString(content) {
 		return "trait"
 	}
-	enumRe := regexp.MustCompile(`(?m)^\s*enum\s+` + regexp.QuoteMeta(name))
-	if enumRe.MatchString(content) {
+	if regexp.MustCompile(`(?m)^\s*enum\s+` + quotedName).MatchString(content) {
 		return "enum"
 	}
 	return "class"
@@ -609,13 +614,14 @@ func extractPHPTypeContent(content, typeName, moduleName string) string {
 	builder.WriteString(fmt.Sprintf("PHP %s: %s (in %s)\n", detectPHPTypeKind(content, typeName), typeName, moduleName))
 
 	lines := strings.Split(content, "\n")
-	pattern := regexp.MustCompile(`^\s*(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+` + regexp.QuoteMeta(typeName))
+	// Build pattern using pre-compiled prefix concept + dynamic name suffix
+	typePattern := regexp.MustCompile(`^\s*(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+` + regexp.QuoteMeta(typeName))
 
 	inType := false
 	braceCount := 0
 	for _, line := range lines {
 		if !inType {
-			if pattern.MatchString(line) {
+			if typePattern.MatchString(line) {
 				inType = true
 				braceCount = 0
 			} else {

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -30,24 +30,10 @@ func (p *PHPParser) IsTestFile(path string) bool {
 	name := filepath.Base(path)
 	inTestDir := strings.Contains(path, "/tests/") || strings.Contains(path, "/test/")
 	hasTestSuffix := strings.HasSuffix(name, "Test.php") || strings.HasSuffix(name, "_test.php")
-	// In test directory — always a test file
-	if inTestDir {
-		return true
-	}
-	// Suffix heuristic: exclude known Laravel/WordPress production directories
-	// to avoid false positives on files like app/Models/Test.php
-	if hasTestSuffix {
-		prodDirs := []string{"/app/Models/", "/app/Http/", "/app/Providers/",
-			"/app/Services/", "/app/Actions/", "/app/Livewire/",
-			"/app/Nova/", "/wp-content/", "/wp-admin/", "/wp-includes/"}
-		for _, dir := range prodDirs {
-			if strings.Contains(path, dir) {
-				return false
-			}
-		}
-		return true
-	}
-	return false
+	// Require test directory for suffix-based detection to avoid false positives
+	// on production files like app/Models/Test.php (the /app/ check uses slashes
+	// on both sides so it won't match paths like /app-testing/)
+	return inTestDir || (hasTestSuffix && !strings.Contains(path, "/app/"))
 }
 
 func (p *PHPParser) ParseFile(root, path string, extractSymbols bool) ([]CodeElement, error) {

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -23,7 +23,7 @@ func (p *PHPParser) Extensions() []string {
 }
 
 func (p *PHPParser) CanParse(path string) bool {
-	return strings.HasSuffix(strings.ToLower(path), ".php")
+	return HasExtension(path, p.Extensions())
 }
 
 func (p *PHPParser) IsTestFile(path string) bool {

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -175,25 +175,30 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 	var typeStartDepth int     // brace depth when we entered the type
 	var inHeredoc string       // heredoc/nowdoc closing label (empty = not in heredoc)
 	var inMultilineConst bool  // inside a multi-line const = [...];
+	var inBlockComment bool    // inside a /* ... */ block comment
 	var skipUntilLine int      // skip lines consumed by multi-line constructor scan
 
 	for i, line := range lines {
 		lineNum := i + 1
 
 		// Skip lines already consumed by multi-line constructor param scan
+		// Braces were already counted during the lookahead — do NOT re-count.
 		if lineNum <= skipUntilLine {
-			// Still count braces for context tracking
-			openBraces := strings.Count(line, "{")
-			closeBraces := strings.Count(line, "}")
-			if currentType != "" {
-				braceDepth += openBraces - closeBraces
-				if braceDepth <= typeStartDepth {
-					currentType = ""
-					currentTypeKind = ""
-				}
-			} else {
-				braceDepth += openBraces - closeBraces
+			continue
+		}
+
+		// Track block comments
+		if inBlockComment {
+			if strings.Contains(line, "*/") {
+				inBlockComment = false
 			}
+			continue
+		}
+		if strings.Contains(strings.TrimSpace(line), "/*") && !strings.Contains(line, "*/") {
+			inBlockComment = true
+			// Still count braces on this line (before the comment marker)
+			braceDepth += countBracesOutsideStrings(line)
+			updateTypeScope(&currentType, &currentTypeKind, &braceDepth, typeStartDepth)
 			continue
 		}
 
@@ -219,20 +224,15 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 			continue
 		}
 
-		// Count braces for context tracking
-		openBraces := strings.Count(line, "{")
-		closeBraces := strings.Count(line, "}")
+		// Count braces using string-aware counting (skips braces inside quotes)
+		braceDelta := countBracesOutsideStrings(line)
+		braceDepth += braceDelta
+		if braceDepth < 0 {
+			braceDepth = 0
+		}
 
 		// Check if we've exited the current type
-		if currentType != "" {
-			braceDepth += openBraces - closeBraces
-			if braceDepth <= typeStartDepth {
-				currentType = ""
-				currentTypeKind = ""
-			}
-		} else {
-			braceDepth += openBraces - closeBraces
-		}
+		updateTypeScope(&currentType, &currentTypeKind, &braceDepth, typeStartDepth)
 
 		trimmed := strings.TrimSpace(line)
 
@@ -295,10 +295,11 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 				for j := i + 1; j < len(lines); j++ {
 					paramLine := lines[j]
 					paramLineNum := j + 1
-					// Count braces on param lines too
-					openBraces := strings.Count(paramLine, "{")
-					closeBraces := strings.Count(paramLine, "}")
-					braceDepth += openBraces - closeBraces
+					// Count braces on param lines (these lines will be skipped by skipUntilLine)
+					braceDepth += countBracesOutsideStrings(paramLine)
+					if braceDepth < 0 {
+						braceDepth = 0
+					}
 
 					for _, m := range promotedPropInParens.FindAllStringSubmatch(paramLine, -1) {
 						symbols = append(symbols, Symbol{
@@ -365,7 +366,7 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 		if matches := classPattern.FindStringSubmatch(line); matches != nil {
 			currentType = matches[1]
 			currentTypeKind = "class"
-			typeStartDepth = braceDepth - openBraces
+			typeStartDepth = braceDepth - braceDelta
 			symbols = append(symbols, Symbol{
 				Name:     matches[1],
 				Type:     "class",
@@ -380,7 +381,7 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 		if matches := interfacePattern.FindStringSubmatch(line); matches != nil {
 			currentType = matches[1]
 			currentTypeKind = "interface"
-			typeStartDepth = braceDepth - openBraces
+			typeStartDepth = braceDepth - braceDelta
 			symbols = append(symbols, Symbol{
 				Name:     matches[1],
 				Type:     "interface",
@@ -395,7 +396,7 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 		if matches := traitPattern.FindStringSubmatch(line); matches != nil {
 			currentType = matches[1]
 			currentTypeKind = "trait"
-			typeStartDepth = braceDepth - openBraces
+			typeStartDepth = braceDepth - braceDelta
 			symbols = append(symbols, Symbol{
 				Name:     matches[1],
 				Type:     "trait",
@@ -410,7 +411,7 @@ func (p *PHPParser) extractSymbols(content string) []Symbol {
 		if matches := enumPattern.FindStringSubmatch(line); matches != nil {
 			currentType = matches[1]
 			currentTypeKind = "enum"
-			typeStartDepth = braceDepth - openBraces
+			typeStartDepth = braceDepth - braceDelta
 			symbols = append(symbols, Symbol{
 				Name:     matches[1],
 				Type:     "enum",
@@ -608,11 +609,74 @@ func extractPHPTypeContent(content, typeName, moduleName string) string {
 		}
 
 		builder.WriteString(line + "\n")
-		braceCount += strings.Count(line, "{") - strings.Count(line, "}")
+		braceCount += countBracesOutsideStrings(line)
 		if inType && braceCount <= 0 && strings.Contains(line, "}") {
 			break
 		}
 	}
 
 	return TruncateContent(builder.String(), 4000)
+}
+
+// countBracesOutsideStrings counts { and } braces on a line while skipping
+// braces inside single-quoted, double-quoted strings, and inline comments.
+// Returns (opens - closes) as a signed delta.
+func countBracesOutsideStrings(line string) int {
+	delta := 0
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	for j := 0; j < len(line); j++ {
+		ch := line[j]
+
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+
+		// Skip rest of line on single-line comment (// or #)
+		if !inSingle && !inDouble {
+			if ch == '/' && j+1 < len(line) && line[j+1] == '/' {
+				break
+			}
+			if ch == '#' && (j+1 >= len(line) || line[j+1] != '[') {
+				// PHP # comment (but not #[ attribute)
+				break
+			}
+		}
+
+		if ch == '\'' && !inDouble {
+			inSingle = !inSingle
+			continue
+		}
+		if ch == '"' && !inSingle {
+			inDouble = !inDouble
+			continue
+		}
+		if inSingle || inDouble {
+			continue
+		}
+
+		switch ch {
+		case '{':
+			delta++
+		case '}':
+			delta--
+		}
+	}
+	return delta
+}
+
+// updateTypeScope resets currentType/currentTypeKind when braceDepth falls
+// to or below the type's starting depth.
+func updateTypeScope(currentType, currentTypeKind *string, braceDepth *int, typeStartDepth int) {
+	if *currentType != "" && *braceDepth <= typeStartDepth {
+		*currentType = ""
+		*currentTypeKind = ""
+	}
 }

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -578,20 +578,45 @@ func detectPHPFrameworkTags(relPath, content string) []string {
 }
 
 // detectPHPTypeKind determines whether a name is a class, interface, trait, or enum.
-// Note: regex is compiled per call because the pattern includes the dynamic type name.
-// This runs once per class/interface/trait/enum in the file (typically < 10 calls).
+// Uses line-based string matching to avoid regex compilation in loops.
 func detectPHPTypeKind(content, name string) string {
-	quotedName := regexp.QuoteMeta(name)
-	if regexp.MustCompile(`(?m)^\s*interface\s+` + quotedName).MatchString(content) {
-		return "interface"
-	}
-	if regexp.MustCompile(`(?m)^\s*trait\s+` + quotedName).MatchString(content) {
-		return "trait"
-	}
-	if regexp.MustCompile(`(?m)^\s*enum\s+` + quotedName).MatchString(content) {
-		return "enum"
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if matchesTypeKeyword(trimmed, "interface", name) {
+			return "interface"
+		}
+		if matchesTypeKeyword(trimmed, "trait", name) {
+			return "trait"
+		}
+		if matchesTypeKeyword(trimmed, "enum", name) {
+			return "enum"
+		}
 	}
 	return "class"
+}
+
+// matchesTypeKeyword checks if a trimmed line declares a type with the given keyword and name.
+// Handles optional modifiers (abstract, final, readonly) before the keyword.
+func matchesTypeKeyword(trimmed, keyword, name string) bool {
+	// Strip optional leading modifiers
+	for _, mod := range []string{"abstract ", "final ", "readonly "} {
+		if strings.HasPrefix(trimmed, mod) {
+			trimmed = strings.TrimSpace(trimmed[len(mod):])
+		}
+	}
+	prefix := keyword + " "
+	if !strings.HasPrefix(trimmed, prefix) {
+		return false
+	}
+	rest := trimmed[len(prefix):]
+	// The name should be the next word
+	return strings.HasPrefix(rest, name) &&
+		(len(rest) == len(name) || !isWordChar(rest[len(name)]))
+}
+
+// isWordChar returns true if c is a letter, digit, or underscore.
+func isWordChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
 }
 
 // extractPHPTypeContent extracts the definition block for a class/interface/trait/enum.
@@ -600,14 +625,16 @@ func extractPHPTypeContent(content, typeName, moduleName string) string {
 	builder.WriteString(fmt.Sprintf("PHP %s: %s (in %s)\n", detectPHPTypeKind(content, typeName), typeName, moduleName))
 
 	lines := strings.Split(content, "\n")
-	// Build pattern using pre-compiled prefix concept + dynamic name suffix
-	typePattern := regexp.MustCompile(`^\s*(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+` + regexp.QuoteMeta(typeName))
 
 	inType := false
 	braceCount := 0
 	for _, line := range lines {
 		if !inType {
-			if typePattern.MatchString(line) {
+			trimmed := strings.TrimSpace(line)
+			if matchesTypeKeyword(trimmed, "class", typeName) ||
+				matchesTypeKeyword(trimmed, "interface", typeName) ||
+				matchesTypeKeyword(trimmed, "trait", typeName) ||
+				matchesTypeKeyword(trimmed, "enum", typeName) {
 				inType = true
 				braceCount = 0
 			} else {

--- a/internal/languages/php_parser.go
+++ b/internal/languages/php_parser.go
@@ -1,0 +1,618 @@
+package languages
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func init() {
+	Register(&PHPParser{})
+}
+
+// PHPParser implements LanguageParser for PHP source files.
+type PHPParser struct{}
+
+func (p *PHPParser) Name() string {
+	return "php"
+}
+
+func (p *PHPParser) Extensions() []string {
+	return []string{".php"}
+}
+
+func (p *PHPParser) CanParse(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".php")
+}
+
+func (p *PHPParser) IsTestFile(path string) bool {
+	name := filepath.Base(path)
+	inTestDir := strings.Contains(path, "/tests/") || strings.Contains(path, "/test/")
+	hasTestSuffix := strings.HasSuffix(name, "Test.php") || strings.HasSuffix(name, "_test.php")
+	// Require test directory for suffix-based detection to avoid false positives
+	// on production files like app/Models/Test.php
+	return inTestDir || (hasTestSuffix && !strings.Contains(path, "/app/"))
+}
+
+func (p *PHPParser) ParseFile(root, path string, extractSymbols bool) ([]CodeElement, error) {
+	var elements []CodeElement
+
+	content, err := ReadFileContent(path)
+	if err != nil {
+		return nil, err
+	}
+
+	relPath, _ := filepath.Rel(root, path)
+	fileName := filepath.Base(path)
+	moduleName := strings.TrimSuffix(fileName, ".php")
+
+	// Extract top-level constructs for the summary
+	classes := FindAllMatches(content, `(?m)^\s*(?:abstract\s+|final\s+|readonly\s+)*class\s+(\w+)`)
+	interfaces := FindAllMatches(content, `(?m)^\s*interface\s+(\w+)`)
+	traits := FindAllMatches(content, `(?m)^\s*trait\s+(\w+)`)
+	enums := FindAllMatches(content, `(?m)^\s*enum\s+(\w+)`)
+	functions := FindAllMatches(content, `(?m)^\s*function\s+(\w+)\s*\(`)
+	namespaces := FindAllMatches(content, `(?m)^\s*namespace\s+([\w\\]+)`)
+
+	// Build content for embedding
+	var contentBuilder strings.Builder
+	contentBuilder.WriteString(fmt.Sprintf("PHP module: %s\n", moduleName))
+	contentBuilder.WriteString(fmt.Sprintf("File: %s\n", relPath))
+
+	if len(namespaces) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Namespace: %s\n", strings.Join(uniqueStrings(namespaces), ", ")))
+	}
+	if len(classes) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Classes: %s\n", strings.Join(uniqueStrings(classes), ", ")))
+	}
+	if len(interfaces) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Interfaces: %s\n", strings.Join(uniqueStrings(interfaces), ", ")))
+	}
+	if len(traits) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Traits: %s\n", strings.Join(uniqueStrings(traits), ", ")))
+	}
+	if len(enums) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Enums: %s\n", strings.Join(uniqueStrings(enums), ", ")))
+	}
+	if len(functions) > 0 {
+		contentBuilder.WriteString(fmt.Sprintf("Functions: %s\n", strings.Join(uniqueStrings(functions), ", ")))
+	}
+
+	contentBuilder.WriteString("\n--- Code ---\n")
+	truncated, wasTruncated := TruncateContentWithInfo(content, 4000)
+	contentBuilder.WriteString(truncated)
+
+	// Detect concerns and build tags
+	concerns := DetectConcerns(relPath, content)
+	tags := []string{"php", "module"}
+	tags = append(tags, concerns...)
+	tags = append(tags, detectPHPFrameworkTags(relPath, content)...)
+
+	// Extract symbols
+	var symbols []Symbol
+	if extractSymbols {
+		symbols = p.extractSymbols(content)
+	}
+
+	// Build diagnostics
+	var diagnostics []Diagnostic
+	if wasTruncated {
+		diagnostics = append(diagnostics, NewDiagnosticWithContext("info", "TRUNCATED", "File content exceeded 4000 character limit", "php", nil))
+	}
+
+	elements = append(elements, CodeElement{
+		Name:        moduleName,
+		Kind:        "module",
+		Path:        "/" + relPath,
+		Content:     contentBuilder.String(),
+		Package:     moduleName,
+		FilePath:    relPath,
+		Tags:        tags,
+		Concerns:    concerns,
+		Symbols:     symbols,
+		Diagnostics: diagnostics,
+	})
+
+	// Add classes, interfaces, traits, and enums as separate elements
+	allTypes := append(uniqueStrings(classes), uniqueStrings(interfaces)...)
+	allTypes = append(allTypes, uniqueStrings(traits)...)
+	allTypes = append(allTypes, uniqueStrings(enums)...)
+
+	for _, typeName := range allTypes {
+		kind := detectPHPTypeKind(content, typeName)
+		typeContent := extractPHPTypeContent(content, typeName, moduleName)
+		elements = append(elements, CodeElement{
+			Name:     typeName,
+			Kind:     kind,
+			Path:     fmt.Sprintf("/%s#%s", relPath, typeName),
+			Content:  typeContent,
+			Package:  moduleName,
+			FilePath: relPath,
+			Tags:     append([]string{"php", kind}, concerns...),
+			Concerns: concerns,
+		})
+	}
+
+	return elements, nil
+}
+
+func (p *PHPParser) extractSymbols(content string) []Symbol {
+	var symbols []Symbol
+	lines := strings.Split(content, "\n")
+
+	// Regex patterns
+	namespacePattern := regexp.MustCompile(`^\s*namespace\s+([\w\\]+)`)
+	classPattern := regexp.MustCompile(`^\s*(?:abstract\s+|final\s+|readonly\s+)*class\s+(\w+)`)
+	interfacePattern := regexp.MustCompile(`^\s*interface\s+(\w+)`)
+	traitPattern := regexp.MustCompile(`^\s*trait\s+(\w+)`)
+	enumPattern := regexp.MustCompile(`^\s*enum\s+(\w+)`)
+	enumCasePattern := regexp.MustCompile(`^\s*case\s+(\w+)`)
+	// Method with visibility modifier (handles abstract/static before or after visibility)
+	methodPattern := regexp.MustCompile(`^\s*(?:abstract\s+)?(?:static\s+)?(public|protected|private)\s+(?:static\s+)?(?:abstract\s+)?function\s+&?(\w+)\s*\(`)
+	// Bare method without visibility (WordPress/legacy PHP style — defaults to public)
+	bareMethodPattern := regexp.MustCompile(`^\s*(?:abstract\s+)?(?:static\s+)?function\s+&?(\w+)\s*\(`)
+	// Top-level function — allow indentation for guarded functions: if (! function_exists(...)) { function foo() }
+	topFuncPattern := regexp.MustCompile(`^\s*function\s+&?(\w+)\s*\(`)
+	// Class constant: optional visibility + const (value captured loosely, handles trailing comments)
+	classConstPattern := regexp.MustCompile(`^\s*(public|protected|private)?\s*const\s+(\w+)\s*=\s*(.+?)\s*;`)
+	// Multi-line class constant (opens with = [ and no ;)
+	classConstMultilinePattern := regexp.MustCompile(`^\s*(public|protected|private)?\s*const\s+(\w+)\s*=\s*\[`)
+	// Top-level constant (handles trailing comments)
+	topConstPattern := regexp.MustCompile(`^\s*const\s+(\w+)\s*=\s*(.+?)\s*;`)
+	// define() constant
+	definePattern := regexp.MustCompile(`^\s*define\s*\(\s*['"](\w+)['"]\s*,\s*(.+?)\)\s*;`)
+	// Property/field with visibility (handles static before or after visibility)
+	fieldPattern := regexp.MustCompile(`^\s*(?:static\s+)?(public|protected|private)\s+(?:static\s+)?(?:readonly\s+)?(?:[\w\\?|]+\s+)?\$(\w+)`)
+	// Constructor promoted property — scans parameter content between parens
+	promotedPropInParens := regexp.MustCompile(`(?:^|,)\s*(public|protected|private)\s+(?:readonly\s+)?(?:[\w\\?|]+\s+)?\$(\w+)`)
+	// Heredoc/nowdoc opener
+	heredocPattern := regexp.MustCompile(`<<<\s*'?(\w+)'?\s*$`)
+
+	var currentType string     // current class/interface/trait/enum name
+	var currentTypeKind string // "class", "interface", "trait", "enum"
+	var braceDepth int         // track brace nesting
+	var typeStartDepth int     // brace depth when we entered the type
+	var inHeredoc string       // heredoc/nowdoc closing label (empty = not in heredoc)
+	var inMultilineConst bool  // inside a multi-line const = [...];
+	var skipUntilLine int      // skip lines consumed by multi-line constructor scan
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		// Skip lines already consumed by multi-line constructor param scan
+		if lineNum <= skipUntilLine {
+			// Still count braces for context tracking
+			openBraces := strings.Count(line, "{")
+			closeBraces := strings.Count(line, "}")
+			if currentType != "" {
+				braceDepth += openBraces - closeBraces
+				if braceDepth <= typeStartDepth {
+					currentType = ""
+					currentTypeKind = ""
+				}
+			} else {
+				braceDepth += openBraces - closeBraces
+			}
+			continue
+		}
+
+		// Skip heredoc/nowdoc content
+		if inHeredoc != "" {
+			if strings.TrimSpace(line) == inHeredoc || strings.TrimSpace(line) == inHeredoc+";" {
+				inHeredoc = ""
+			}
+			continue
+		}
+
+		// Detect heredoc/nowdoc opener
+		if matches := heredocPattern.FindStringSubmatch(line); matches != nil {
+			inHeredoc = matches[1]
+			// Still process this line for brace counting below
+		}
+
+		// Skip multi-line const array body
+		if inMultilineConst {
+			if strings.Contains(line, "];") {
+				inMultilineConst = false
+			}
+			continue
+		}
+
+		// Count braces for context tracking
+		openBraces := strings.Count(line, "{")
+		closeBraces := strings.Count(line, "}")
+
+		// Check if we've exited the current type
+		if currentType != "" {
+			braceDepth += openBraces - closeBraces
+			if braceDepth <= typeStartDepth {
+				currentType = ""
+				currentTypeKind = ""
+			}
+		} else {
+			braceDepth += openBraces - closeBraces
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		// Skip empty lines and comments
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") || strings.HasPrefix(trimmed, "#[") {
+			continue
+		}
+
+		// Constructor handling: emit __construct as method AND extract promoted properties
+		if currentType != "" && strings.Contains(trimmed, "function __construct(") {
+			// Emit __construct as a method symbol
+			constructorVisibility := "public"
+			if strings.Contains(trimmed, "private function") || strings.Contains(trimmed, "private static function") {
+				constructorVisibility = "private"
+			} else if strings.Contains(trimmed, "protected function") || strings.Contains(trimmed, "protected static function") {
+				constructorVisibility = "protected"
+			}
+			symbols = append(symbols, Symbol{
+				Name:     "__construct",
+				Type:     "method",
+				Line:     lineNum,
+				Exported: constructorVisibility == "public",
+				Parent:   currentType,
+				Language: "php",
+			})
+
+			// Extract promoted properties from constructor params
+			// Collect all parameter text (may span multiple lines)
+			paramText := ""
+			if idx := strings.Index(line, "__construct("); idx >= 0 {
+				paramText = line[idx+len("__construct("):]
+			}
+			if strings.Contains(paramText, ")") {
+				// Single-line constructor — extract params before )
+				if closeIdx := strings.Index(paramText, ")"); closeIdx >= 0 {
+					paramText = paramText[:closeIdx]
+				}
+				for _, m := range promotedPropInParens.FindAllStringSubmatch(paramText, -1) {
+					symbols = append(symbols, Symbol{
+						Name:     strings.TrimPrefix(m[2], "$"),
+						Type:     "field",
+						Line:     lineNum,
+						Exported: m[1] == "public",
+						Parent:   currentType,
+						Language: "php",
+					})
+				}
+			} else {
+				// Multi-line constructor — scan subsequent lines until )
+				for _, m := range promotedPropInParens.FindAllStringSubmatch(paramText, -1) {
+					symbols = append(symbols, Symbol{
+						Name:     strings.TrimPrefix(m[2], "$"),
+						Type:     "field",
+						Line:     lineNum,
+						Exported: m[1] == "public",
+						Parent:   currentType,
+						Language: "php",
+					})
+				}
+				for j := i + 1; j < len(lines); j++ {
+					paramLine := lines[j]
+					paramLineNum := j + 1
+					// Count braces on param lines too
+					openBraces := strings.Count(paramLine, "{")
+					closeBraces := strings.Count(paramLine, "}")
+					braceDepth += openBraces - closeBraces
+
+					for _, m := range promotedPropInParens.FindAllStringSubmatch(paramLine, -1) {
+						symbols = append(symbols, Symbol{
+							Name:     strings.TrimPrefix(m[2], "$"),
+							Type:     "field",
+							Line:     paramLineNum,
+							Exported: m[1] == "public",
+							Parent:   currentType,
+							Language: "php",
+						})
+					}
+					if strings.Contains(paramLine, ")") {
+						skipUntilLine = paramLineNum
+						break
+					}
+				}
+			}
+			continue
+		}
+
+		// Namespace
+		if matches := namespacePattern.FindStringSubmatch(line); matches != nil {
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "namespace",
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Top-level define() constant
+		if matches := definePattern.FindStringSubmatch(line); matches != nil {
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "constant",
+				Value:    CleanValue(matches[2]),
+				RawValue: matches[2],
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Top-level const
+		if currentType == "" {
+			if matches := topConstPattern.FindStringSubmatch(line); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[1],
+					Type:     "constant",
+					Value:    CleanValue(matches[2]),
+					RawValue: matches[2],
+					Line:     lineNum,
+					Exported: true,
+					Language: "php",
+				})
+				continue
+			}
+		}
+
+		// Class definition
+		if matches := classPattern.FindStringSubmatch(line); matches != nil {
+			currentType = matches[1]
+			currentTypeKind = "class"
+			typeStartDepth = braceDepth - openBraces
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "class",
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Interface definition
+		if matches := interfacePattern.FindStringSubmatch(line); matches != nil {
+			currentType = matches[1]
+			currentTypeKind = "interface"
+			typeStartDepth = braceDepth - openBraces
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "interface",
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Trait definition
+		if matches := traitPattern.FindStringSubmatch(line); matches != nil {
+			currentType = matches[1]
+			currentTypeKind = "trait"
+			typeStartDepth = braceDepth - openBraces
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "trait",
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Enum definition
+		if matches := enumPattern.FindStringSubmatch(line); matches != nil {
+			currentType = matches[1]
+			currentTypeKind = "enum"
+			typeStartDepth = braceDepth - openBraces
+			symbols = append(symbols, Symbol{
+				Name:     matches[1],
+				Type:     "enum",
+				Line:     lineNum,
+				Exported: true,
+				Language: "php",
+			})
+			continue
+		}
+
+		// Enum case (inside enum)
+		if currentType != "" && currentTypeKind == "enum" {
+			if matches := enumCasePattern.FindStringSubmatch(trimmed); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[1],
+					Type:     "enum_value",
+					Line:     lineNum,
+					Exported: true,
+					Parent:   currentType,
+					Language: "php",
+				})
+				continue
+			}
+		}
+
+		// Class/trait constant (multi-line array form: const NAME = [...])
+		if currentType != "" {
+			if matches := classConstMultilinePattern.FindStringSubmatch(trimmed); matches != nil {
+				if !strings.Contains(trimmed, "];") {
+					// Value spans multiple lines — record the constant, skip the array body
+					visibility := matches[1]
+					if visibility == "" {
+						visibility = "public"
+					}
+					symbols = append(symbols, Symbol{
+						Name:     matches[2],
+						Type:     "constant",
+						Line:     lineNum,
+						Exported: visibility == "public",
+						Parent:   currentType,
+						Language: "php",
+					})
+					inMultilineConst = true
+					continue
+				}
+			}
+		}
+
+		// Class/trait constant (single-line)
+		if currentType != "" {
+			if matches := classConstPattern.FindStringSubmatch(trimmed); matches != nil {
+				visibility := matches[1]
+				if visibility == "" {
+					visibility = "public"
+				}
+				symbols = append(symbols, Symbol{
+					Name:     matches[2],
+					Type:     "constant",
+					Value:    CleanValue(matches[3]),
+					RawValue: matches[3],
+					Line:     lineNum,
+					Exported: visibility == "public",
+					Parent:   currentType,
+					Language: "php",
+				})
+				continue
+			}
+		}
+
+		// Field/property (inside class/trait, not in method)
+		if currentType != "" && (currentTypeKind == "class" || currentTypeKind == "trait") {
+			if matches := fieldPattern.FindStringSubmatch(trimmed); matches != nil {
+				// Skip if this looks like a method parameter or local var
+				if !strings.Contains(trimmed, "function ") {
+					symbols = append(symbols, Symbol{
+						Name:     matches[2],
+						Type:     "field",
+						Line:     lineNum,
+						Exported: matches[1] == "public",
+						Parent:   currentType,
+						Language: "php",
+					})
+					continue
+				}
+			}
+		}
+
+		// Method with visibility (inside a type)
+		if currentType != "" {
+			if matches := methodPattern.FindStringSubmatch(trimmed); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[2],
+					Type:     "method",
+					Line:     lineNum,
+					Exported: matches[1] == "public",
+					Parent:   currentType,
+					Language: "php",
+				})
+				continue
+			}
+			// Bare method without visibility (WordPress/legacy style — defaults to public)
+			if matches := bareMethodPattern.FindStringSubmatch(trimmed); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[1],
+					Type:     "method",
+					Line:     lineNum,
+					Exported: true, // PHP bare methods default to public
+					Parent:   currentType,
+					Language: "php",
+				})
+				continue
+			}
+		}
+
+		// Top-level function (allow indentation for guarded functions)
+		if currentType == "" {
+			if matches := topFuncPattern.FindStringSubmatch(line); matches != nil {
+				symbols = append(symbols, Symbol{
+					Name:     matches[1],
+					Type:     "function",
+					Line:     lineNum,
+					Exported: true,
+					Language: "php",
+				})
+				continue
+			}
+		}
+	}
+
+	return symbols
+}
+
+// detectPHPFrameworkTags returns framework-specific tags based on path and content.
+func detectPHPFrameworkTags(relPath, content string) []string {
+	var tags []string
+
+	// Laravel detection
+	if strings.Contains(relPath, "app/Models") ||
+		strings.Contains(relPath, "app/Http") ||
+		strings.Contains(relPath, "app/Providers") ||
+		strings.Contains(relPath, "routes/") ||
+		strings.Contains(content, "use Illuminate\\") ||
+		strings.Contains(content, "extends Model") ||
+		strings.Contains(content, "extends Controller") {
+		tags = append(tags, "laravel")
+	}
+
+	// WordPress detection
+	if strings.Contains(content, "add_action(") ||
+		strings.Contains(content, "add_filter(") ||
+		strings.Contains(content, "WP_") ||
+		strings.Contains(content, "wp_") ||
+		strings.Contains(relPath, "wp-content/") {
+		tags = append(tags, "wordpress")
+	}
+
+	return tags
+}
+
+// detectPHPTypeKind determines whether a name is a class, interface, trait, or enum.
+func detectPHPTypeKind(content, name string) string {
+	interfaceRe := regexp.MustCompile(`(?m)^\s*interface\s+` + regexp.QuoteMeta(name))
+	if interfaceRe.MatchString(content) {
+		return "interface"
+	}
+	traitRe := regexp.MustCompile(`(?m)^\s*trait\s+` + regexp.QuoteMeta(name))
+	if traitRe.MatchString(content) {
+		return "trait"
+	}
+	enumRe := regexp.MustCompile(`(?m)^\s*enum\s+` + regexp.QuoteMeta(name))
+	if enumRe.MatchString(content) {
+		return "enum"
+	}
+	return "class"
+}
+
+// extractPHPTypeContent extracts the definition block for a class/interface/trait/enum.
+func extractPHPTypeContent(content, typeName, moduleName string) string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("PHP %s: %s (in %s)\n", detectPHPTypeKind(content, typeName), typeName, moduleName))
+
+	lines := strings.Split(content, "\n")
+	pattern := regexp.MustCompile(`^\s*(?:abstract\s+|final\s+|readonly\s+)*(?:class|interface|trait|enum)\s+` + regexp.QuoteMeta(typeName))
+
+	inType := false
+	braceCount := 0
+	for _, line := range lines {
+		if !inType {
+			if pattern.MatchString(line) {
+				inType = true
+				braceCount = 0
+			} else {
+				continue
+			}
+		}
+
+		builder.WriteString(line + "\n")
+		braceCount += strings.Count(line, "{") - strings.Count(line, "}")
+		if inType && braceCount <= 0 && strings.Contains(line, "}") {
+			break
+		}
+	}
+
+	return TruncateContent(builder.String(), 4000)
+}

--- a/scripts/php_parser_verify.go
+++ b/scripts/php_parser_verify.go
@@ -1,0 +1,86 @@
+// +build ignore
+
+// php_parser_verify.go — standalone tool to extract PHP symbols from a file or directory.
+// Usage: go run scripts/php_parser_verify.go <path> [path2 ...]
+// If path is a directory, recursively finds all .php files (excluding vendor/node_modules).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"mdemg/internal/languages"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <path> [path2 ...]\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	parser := &languages.PHPParser{}
+	var allFiles []string
+
+	for _, arg := range os.Args[1:] {
+		info, err := os.Stat(arg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s: %v\n", arg, err)
+			continue
+		}
+		if info.IsDir() {
+			filepath.Walk(arg, func(path string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return nil
+				}
+				if fi.IsDir() {
+					base := filepath.Base(path)
+					if base == "vendor" || base == "node_modules" || base == ".git" {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+				if strings.HasSuffix(path, ".php") {
+					allFiles = append(allFiles, path)
+				}
+				return nil
+			})
+		} else if strings.HasSuffix(arg, ".php") {
+			allFiles = append(allFiles, arg)
+		}
+	}
+
+	type FileResult struct {
+		File    string             `json:"file"`
+		Symbols []languages.Symbol `json:"symbols"`
+		Error   string             `json:"error,omitempty"`
+	}
+
+	var results []FileResult
+	totalSymbols := 0
+
+	for _, f := range allFiles {
+		root := filepath.Dir(f)
+		elements, err := parser.ParseFile(root, f, true)
+		if err != nil {
+			results = append(results, FileResult{File: f, Error: err.Error()})
+			continue
+		}
+		var syms []languages.Symbol
+		for _, el := range elements {
+			syms = append(syms, el.Symbols...)
+		}
+		if len(syms) > 0 {
+			results = append(results, FileResult{File: f, Symbols: syms})
+			totalSymbols += len(syms)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Scanned %d PHP files, found %d with symbols, %d total symbols\n", len(allFiles), len(results), totalSymbols)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(results)
+}

--- a/scripts/php_parser_verify.go
+++ b/scripts/php_parser_verify.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 // php_parser_verify.go — standalone tool to extract PHP symbols from a file or directory.
 // Usage: go run scripts/php_parser_verify.go <path> [path2 ...]
@@ -60,12 +60,15 @@ func main() {
 
 	var results []FileResult
 	totalSymbols := 0
+	filesWithSymbols := 0
+	parseErrors := 0
 
 	for _, f := range allFiles {
 		root := filepath.Dir(f)
 		elements, err := parser.ParseFile(root, f, true)
 		if err != nil {
 			results = append(results, FileResult{File: f, Error: err.Error()})
+			parseErrors++
 			continue
 		}
 		var syms []languages.Symbol
@@ -75,10 +78,15 @@ func main() {
 		if len(syms) > 0 {
 			results = append(results, FileResult{File: f, Symbols: syms})
 			totalSymbols += len(syms)
+			filesWithSymbols++
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, "Scanned %d PHP files, found %d with symbols, %d total symbols\n", len(allFiles), len(results), totalSymbols)
+	fmt.Fprintf(os.Stderr, "Scanned %d PHP files, found %d with symbols, %d total symbols", len(allFiles), filesWithSymbols, totalSymbols)
+	if parseErrors > 0 {
+		fmt.Fprintf(os.Stderr, " (%d parse errors)", parseErrors)
+	}
+	fmt.Fprintln(os.Stderr)
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")


### PR DESCRIPTION
## Summary

- Add PHP language parser supporting classes, interfaces, traits, enums, functions, constants, namespaces, fields, and methods
- Handles Laravel conventions (Eloquent models, controllers, middleware) and WordPress conventions (hooks, `define()`, bare methods)
- Includes UPTS spec with 51 expected symbols covering 9 pattern codes and 11 regression test cases

## Motivation

PHP was listed in the MDEMG parser roadmap as a candidate for future support. Laravel is one of the most actively developed web frameworks, with a growing ecosystem around AI-assisted development (Laravel Boost, AI SDK). WordPress famously powers roughly 1/3 of the web (for better or worse). Together they represent a significant share of production PHP codebases that would benefit from MDEMG ingestion. I also have a personal interest because most of my projects are Laravel apps, with a few WordPress sites thrown in for good measure.

## PHP constructs supported

| Construct | Symbol Type | Pattern |
|---|---|---|
| `namespace` | namespace | P5_NAMESPACE |
| `class` (incl. abstract, final, readonly) | class | P3_CLASS_STRUCT |
| `interface` | interface | P4_INTERFACE_TRAIT |
| `trait` | trait | P4_INTERFACE_TRAIT |
| `enum` + `case` values | enum, enum_value | P5_ENUM, P5_ENUM_VALUE |
| Methods (all visibility, bare, static, abstract, reference-return) | method | P6_METHOD |
| Standalone functions (incl. indented/guarded) | function | P2_FUNCTION |
| Constants (`const`, `define()`, multi-line arrays, trailing comments) | constant | P1_CONSTANT |
| Properties/fields (incl. constructor promoted, reversed static order) | field | P9_FIELD |

## Edge cases handled

These were discovered by running the parser against 20,184 PHP files across 7 real codebases (3 WordPress, 4 Laravel) and are covered by regression tests in the UPTS fixture:

- Heredoc/nowdoc content skipped (prevents false-positive JS `const` symbols)
- Multi-line array constants (`const FOO = [...]`)
- Constants with trailing comments (`const FOO = 1; // comment`)
- `__construct` emitted as method symbol + promoted properties extracted
- Single-line constructor promoted properties
- Bare methods without visibility modifier (WordPress/legacy PHP style)
- Reversed modifier order (`static public function`, `static protected $field`)
- `readonly class` (PHP 8.2)
- Reference-return methods (`function &name()`)
- Indented guarded functions (`if (!function_exists(...)) { function foo() {} }`)
- `IsTestFile` avoids false positives on production models named `*Test.php`

## Framework detection

The parser auto-tags files with `"laravel"` or `"wordpress"` based on path patterns and content markers, enabling framework-aware retrieval.

## Known limitations

- `abstract`/`final`/`static` modifiers not stored in Symbol struct (would require cross-parser struct changes)
- Anonymous class methods attributed to enclosing named class (rare edge case)
- `CleanValue()` truncates URL strings at `//` (shared utility across all parsers)
- Multi-line `define()` calls not captured (single-line only)

## Test plan

- [x] UPTS spec: 51/51 symbols matched, 0 failures
- [x] Full UPTS suite: 28/28 language parsers pass (zero regressions)
- [x] `golangci-lint run`: 0 issues
- [x] `gofmt`: clean
- [x] Verified against 7 real codebases (3 WordPress, 4 Laravel — 20,184 PHP files, 163,790 symbols extracted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)