### PR TITLE
fix: add 6 missing languages to ingester enabled map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,11 +130,12 @@ Specs live in `docs/lang-parser/lang-parse-spec/upts/specs/`. Fixtures live in `
 
 When adding a new language parser or modifying an existing one:
 
-1. **Create the parser** in `cmd/ingest-codebase/languages/<language>_parser.go` (see that directory's README for the interface)
+1. **Create the parser** in `internal/languages/<language>_parser.go` (see that directory's README for the interface)
 2. **Create a fixture** — a representative source file covering all symbol types the parser should extract
 3. **Create a UPTS spec** — JSON file declaring expected symbols with name, type, line number, and export status
-4. **Validate** — run `go test ./cmd/ingest-codebase/languages/ -run TestUPTS/<language> -v` until all assertions pass
-5. **Key spec fields:**
+4. **Register in the ingester** — add the language to `getEnabledLanguages()` in `cmd/ingest-codebase/main.go` (without this, files are silently skipped during ingestion)
+5. **Validate** — run `go test ./internal/languages/ -run TestUPTS/<language> -v` until all assertions pass
+6. **Key spec fields:**
    - `line_tolerance`: how far actual line can be from expected (default ±2)
    - `optional`: set `true` on symbols that may or may not be emitted (e.g., duplicate declarations)
    - `pattern`: document which extraction pattern this symbol tests (e.g., `P2_FUNCTION`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Thank you for your interest in contributing to MDEMG (Multi-Dimensional Emergent
   go test -tags=integration ./tests/integration/...
 
   # Parser validation — Go-native UPTS harness (no external deps)
-  go test ./cmd/ingest-codebase/languages/ -run TestUPTS -v
+  go test ./internal/languages/ -run TestUPTS -v
 
   # Parser validation — Python UPTS runner (requires bin/extract-symbols)
   make test-parsers
@@ -83,7 +83,7 @@ Thank you for your interest in contributing to MDEMG (Multi-Dimensional Emergent
   make test-parser-typescript
 
   # Go-native UPTS for a single language
-  go test ./cmd/ingest-codebase/languages/ -run TestUPTS/rust -v
+  go test ./internal/languages/ -run TestUPTS/rust -v
 
   # API validation (UATS - requires running server)
   make test-api
@@ -113,7 +113,7 @@ All test frameworks in this project follow the **UxTS (Universal-x Test Specific
 
 **UPTS (Universal Parser Test Specification)** validates 27 language parsers against JSON spec files with SHA256 fixture verification. There are two runners:
 
-1. **Go-native test harness** (`cmd/ingest-codebase/languages/upts_test.go`): Loads UPTS specs, parses fixtures through the actual Go parser, and validates output against expected symbols. No external dependencies — runs via standard `go test`. This is the primary validation method.
+1. **Go-native test harness** (`internal/languages/upts_test.go`): Loads UPTS specs, parses fixtures through the actual Go parser, and validates output against expected symbols. No external dependencies — runs via standard `go test`. This is the primary validation method.
 
 2. **Python runner** (`docs/lang-parser/lang-parse-spec/upts/runners/upts_runner.py`): Validates via the `bin/extract-symbols` CLI binary. Useful for cross-validation and CI.
 
@@ -123,7 +123,7 @@ Specs live in `docs/lang-parser/lang-parse-spec/upts/specs/`. Fixtures live in `
 
 1. Create or edit `docs/lang-parser/lang-parse-spec/upts/specs/<language>.upts.json`
 2. Create or edit the fixture file in `docs/lang-parser/lang-parse-spec/upts/fixtures/`
-3. Run the Go-native harness: `go test ./cmd/ingest-codebase/languages/ -run TestUPTS/<language> -v`
+3. Run the Go-native harness: `go test ./internal/languages/ -run TestUPTS/<language> -v`
 4. Optionally cross-validate with the Python runner: `make test-parser-<language>`
 
 ### Parser Development Workflow

--- a/cmd/ingest-codebase/main.go
+++ b/cmd/ingest-codebase/main.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
-	"mdemg/internal/config"
 	"mdemg/internal/languages"
+	"mdemg/internal/config"
 	"mdemg/internal/summarize"
 )
 
@@ -46,8 +46,13 @@ var (
 	includePy      = flag.Bool("include-py", true, "Include Python files (*.py)")
 	includeJava    = flag.Bool("include-java", true, "Include Java files (*.java)")
 	includeRust    = flag.Bool("include-rust", true, "Include Rust files (*.rs)")
-	includePHP     = flag.Bool("include-php", true, "Include PHP files (*.php)")
-	limitElements  = flag.Int("limit", 0, "Limit number of elements to ingest (0 = no limit)")
+	includePHP      = flag.Bool("include-php", true, "Include PHP files (*.php)")
+	includeGraphQL  = flag.Bool("include-graphql", true, "Include GraphQL files (*.graphql, *.gql)")
+	includeLua      = flag.Bool("include-lua", true, "Include Lua files (*.lua)")
+	includeProtobuf = flag.Bool("include-protobuf", true, "Include Protocol Buffer files (*.proto)")
+	includeOpenAPI  = flag.Bool("include-openapi", true, "Include OpenAPI/Swagger files")
+	includeScraper  = flag.Bool("include-scraper-markdown", true, "Include scraper markdown files")
+	limitElements   = flag.Int("limit", 0, "Limit number of elements to ingest (0 = no limit)")
 	extractSymbols = flag.Bool("extract-symbols", true, "Extract code symbols (constants, functions, classes) for evidence-locked retrieval")
 	incremental    = flag.Bool("incremental", false, "Only ingest files changed since last commit (uses git diff)")
 	sinceCommit    = flag.String("since", "HEAD~1", "Git commit to compare against for incremental mode (default: HEAD~1)")
@@ -68,7 +73,7 @@ var (
 	listLanguages = flag.Bool("list-languages", false, "List supported languages and exit")
 
 	// Phase 2.5: Performance guards for large repos
-	maxFileSize        = flag.Int("max-file-size", 1048576, "Max file size in bytes to process (default: 1MB)")
+	maxFileSize       = flag.Int("max-file-size", 1048576, "Max file size in bytes to process (default: 1MB)")
 	maxElementsPerFile = flag.Int("max-elements-per-file", 500, "Max elements to extract per file (default: 500)")
 	maxSymbolsPerFile  = flag.Int("max-symbols-per-file", 1000, "Max symbols to extract per file (default: 1000)")
 	preset             = flag.String("preset", "", "Exclusion preset: default, ml_cuda, web_monorepo")
@@ -99,8 +104,8 @@ type BatchIngestItem struct {
 type IngestSymbol struct {
 	Name           string `json:"name"`
 	Type           string `json:"type"`
-	Line           int    `json:"line"`               // 1-indexed line number (UPTS standard)
-	LineEnd        int    `json:"line_end,omitempty"` // End line for multi-line symbols
+	Line           int    `json:"line"`                      // 1-indexed line number (UPTS standard)
+	LineEnd        int    `json:"line_end,omitempty"`        // End line for multi-line symbols
 	Exported       bool   `json:"exported"`
 	Parent         string `json:"parent,omitempty"`
 	Signature      string `json:"signature,omitempty"`
@@ -116,7 +121,7 @@ type CodeElement struct {
 	Kind     string
 	Path     string
 	Content  string
-	Summary  string // Brief summary for reranking (generated from docstrings/comments)
+	Summary  string         // Brief summary for reranking (generated from docstrings/comments)
 	Package  string
 	FilePath string
 	Tags     []string
@@ -815,11 +820,11 @@ func getEnabledLanguages() map[string]bool {
 		"terraform":        true,
 		"makefile":         true,
 		"php":              *includePHP,
-		"graphql":          true,
-		"lua":              true,
-		"protobuf":         true,
-		"openapi":          true,
-		"scraper-markdown": true,
+		"graphql":          *includeGraphQL,
+		"lua":              *includeLua,
+		"protobuf":         *includeProtobuf,
+		"openapi":          *includeOpenAPI,
+		"scraper-markdown": *includeScraper,
 	}
 }
 
@@ -1200,6 +1205,7 @@ func parseEnvFile(root, path string) *CodeElement {
 		Concerns: concerns,
 	}
 }
+
 
 // generateSummaryAdapter adapts generateSummary for use with the summarize package.
 // This allows the LLM summarize service to fall back to structural summaries.

--- a/cmd/ingest-codebase/main.go
+++ b/cmd/ingest-codebase/main.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
-	"mdemg/internal/languages"
 	"mdemg/internal/config"
+	"mdemg/internal/languages"
 	"mdemg/internal/summarize"
 )
 
@@ -46,6 +46,7 @@ var (
 	includePy      = flag.Bool("include-py", true, "Include Python files (*.py)")
 	includeJava    = flag.Bool("include-java", true, "Include Java files (*.java)")
 	includeRust    = flag.Bool("include-rust", true, "Include Rust files (*.rs)")
+	includePHP     = flag.Bool("include-php", true, "Include PHP files (*.php)")
 	limitElements  = flag.Int("limit", 0, "Limit number of elements to ingest (0 = no limit)")
 	extractSymbols = flag.Bool("extract-symbols", true, "Extract code symbols (constants, functions, classes) for evidence-locked retrieval")
 	incremental    = flag.Bool("incremental", false, "Only ingest files changed since last commit (uses git diff)")
@@ -67,7 +68,7 @@ var (
 	listLanguages = flag.Bool("list-languages", false, "List supported languages and exit")
 
 	// Phase 2.5: Performance guards for large repos
-	maxFileSize       = flag.Int("max-file-size", 1048576, "Max file size in bytes to process (default: 1MB)")
+	maxFileSize        = flag.Int("max-file-size", 1048576, "Max file size in bytes to process (default: 1MB)")
 	maxElementsPerFile = flag.Int("max-elements-per-file", 500, "Max elements to extract per file (default: 500)")
 	maxSymbolsPerFile  = flag.Int("max-symbols-per-file", 1000, "Max symbols to extract per file (default: 1000)")
 	preset             = flag.String("preset", "", "Exclusion preset: default, ml_cuda, web_monorepo")
@@ -98,8 +99,8 @@ type BatchIngestItem struct {
 type IngestSymbol struct {
 	Name           string `json:"name"`
 	Type           string `json:"type"`
-	Line           int    `json:"line"`                      // 1-indexed line number (UPTS standard)
-	LineEnd        int    `json:"line_end,omitempty"`        // End line for multi-line symbols
+	Line           int    `json:"line"`               // 1-indexed line number (UPTS standard)
+	LineEnd        int    `json:"line_end,omitempty"` // End line for multi-line symbols
 	Exported       bool   `json:"exported"`
 	Parent         string `json:"parent,omitempty"`
 	Signature      string `json:"signature,omitempty"`
@@ -115,7 +116,7 @@ type CodeElement struct {
 	Kind     string
 	Path     string
 	Content  string
-	Summary  string         // Brief summary for reranking (generated from docstrings/comments)
+	Summary  string // Brief summary for reranking (generated from docstrings/comments)
 	Package  string
 	FilePath string
 	Tags     []string
@@ -809,10 +810,16 @@ func getEnabledLanguages() map[string]bool {
 		"cuda":       true,
 		"cypher":     true,
 		// New parsers
-		"csharp":     true,
-		"kotlin":     true,
-		"terraform":  true,
-		"makefile":   true,
+		"csharp":           true,
+		"kotlin":           true,
+		"terraform":        true,
+		"makefile":         true,
+		"php":              *includePHP,
+		"graphql":          true,
+		"lua":              true,
+		"protobuf":         true,
+		"openapi":          true,
+		"scraper-markdown": true,
 	}
 }
 
@@ -1193,7 +1200,6 @@ func parseEnvFile(root, path string) *CodeElement {
 		Concerns: concerns,
 	}
 }
-
 
 // generateSummaryAdapter adapts generateSummary for use with the summarize package.
 // This allows the LLM summarize service to fall back to structural summaries.

--- a/internal/languages/README.md
+++ b/internal/languages/README.md
@@ -263,14 +263,7 @@ See existing specs for examples of the full schema.
 
 ### Step 6: Register in the Ingester
 
-The parser auto-registers in the parser registry via `init()`, but the ingester has a separate enabled-languages gate. Add your language to `getEnabledLanguages()` in `cmd/ingest-codebase/main.go`:
-
-```go
-// In getEnabledLanguages():
-"mylang": true,
-```
-
-For languages that users may want to toggle off, add a CLI flag instead:
+The parser auto-registers in the parser registry via `init()`, but the ingester has a separate enabled-languages gate. Add a CLI flag and wire it into `getEnabledLanguages()` in `cmd/ingest-codebase/main.go`:
 
 ```go
 // At the top with other flags:
@@ -280,7 +273,7 @@ includeMyLang = flag.Bool("include-mylang", true, "Include MyLang files (*.ml)")
 "mylang": *includeMyLang,
 ```
 
-Without this step, `.ml` files will be silently skipped during ingestion even though the parser works.
+All languages must use CLI flags (no hardcoded `true` entries). Without this step, `.ml` files will be silently skipped during ingestion even though the parser works.
 
 ### Step 7: Rebuild
 

--- a/internal/languages/README.md
+++ b/internal/languages/README.md
@@ -261,15 +261,34 @@ Create a fixture file and spec to validate your parser's symbol extraction:
 
 See existing specs for examples of the full schema.
 
-### Step 6: Rebuild
+### Step 6: Register in the Ingester
+
+The parser auto-registers in the parser registry via `init()`, but the ingester has a separate enabled-languages gate. Add your language to `getEnabledLanguages()` in `cmd/ingest-codebase/main.go`:
+
+```go
+// In getEnabledLanguages():
+"mylang": true,
+```
+
+For languages that users may want to toggle off, add a CLI flag instead:
+
+```go
+// At the top with other flags:
+includeMyLang = flag.Bool("include-mylang", true, "Include MyLang files (*.ml)")
+
+// In getEnabledLanguages():
+"mylang": *includeMyLang,
+```
+
+Without this step, `.ml` files will be silently skipped during ingestion even though the parser works.
+
+### Step 7: Rebuild
 
 After adding your parser:
 
 ```bash
 go build ./cmd/ingest-codebase/
 ```
-
-The parser auto-registers via `init()`, so no other changes needed.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add PHP, GraphQL, Lua, Protobuf, OpenAPI, and scraper-markdown to `getEnabledLanguages()` in the ingester
- Add `--include-php` CLI flag (defaults to true, matching Java/Python/Rust/TS convention)
- Update parser development docs to include the ingester registration step

## Motivation

These 6 parsers all self-register via `init()` and work correctly in UPTS tests, but `getEnabledLanguages()` in `cmd/ingest-codebase/main.go` didn't include them. The ingester silently dropped files for these languages at the `enabledLangs` gate (line 864), so they were never actually ingested despite having working parsers.

I discovered this when trying to ingest a Laravel project after my PHP parser PR (#278) was merged. The parser worked in isolation (`extract-symbols --json` confirmed it), but `ingest` produced zero PHP files.

## Root cause

`getEnabledLanguages()` is a manually maintained map. The "Adding a New Language" guide in `internal/languages/README.md` didn't mention this step, which might be why there were 5 other parsers with the same issue. I updated the docs to help prevent it in the future.

## Docs update

Both `internal/languages/README.md` and `CONTRIBUTING.md` now include the ingester registration step. The README adds it as "Step 6: Register in the Ingester" with code examples for both hardcoded and flag-gated approaches. CONTRIBUTING.md's parser workflow also includes the step and fixes stale path references.

## Test plan

- [x] `go build ./cmd/ingest-codebase/` succeeds
- [x] `--include-php` flag visible in `--help`
- [x] `golangci-lint run`: 0 issues
- [x] Dry-run against a Laravel project: 331 elements with 62 classes (was 38 elements with 0 PHP files before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI toggles (default: enabled) to include/exclude PHP, GraphQL, Lua, Protobuf, OpenAPI, and scraper-markdown parsers.

* **Documentation**
  * Clarified language onboarding: new parsers must be registered with the ingester or they will be silently skipped; docs show how to expose a CLI flag.
  * Updated test-harness and parser-location guidance for running per-language and full harnesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->