### PR TITLE
fix(ingest): add 6 missing languages to shipped mdemg binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ When adding a new language parser or modifying an existing one:
 1. **Create the parser** in `internal/languages/<language>_parser.go` (see that directory's README for the interface)
 2. **Create a fixture** — a representative source file covering all symbol types the parser should extract
 3. **Create a UPTS spec** — JSON file declaring expected symbols with name, type, line number, and export status
-4. **Register in the ingester** — add the language to `getEnabledLanguages()` in `cmd/ingest-codebase/main.go` (without this, files are silently skipped during ingestion)
+4. **Register in the ingester** — add the language to `getEnabledLanguages()` in **both** `internal/cli/ingest.go` (the shipped `mdemg` binary) and `cmd/ingest-codebase/main.go` (standalone dev tool). The `internal/cli/ingest.go` registration is what matters for released builds. Without this, files are silently skipped during ingestion.
 5. **Validate** — run `go test ./internal/languages/ -run TestUPTS/<language> -v` until all assertions pass
 6. **Key spec fields:**
    - `line_tolerance`: how far actual line can be from expected (default ±2)

--- a/internal/cli/ingest.go
+++ b/internal/cli/ingest.go
@@ -99,6 +99,12 @@ func newIngestCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&cfg.includePy, "include-py", true, "Include Python files (*.py)")
 	cmd.Flags().BoolVar(&cfg.includeJava, "include-java", true, "Include Java files (*.java)")
 	cmd.Flags().BoolVar(&cfg.includeRust, "include-rust", true, "Include Rust files (*.rs)")
+	cmd.Flags().BoolVar(&cfg.includePHP, "include-php", true, "Include PHP files (*.php)")
+	cmd.Flags().BoolVar(&cfg.includeGraphQL, "include-graphql", true, "Include GraphQL files (*.graphql, *.gql)")
+	cmd.Flags().BoolVar(&cfg.includeLua, "include-lua", true, "Include Lua files (*.lua)")
+	cmd.Flags().BoolVar(&cfg.includeProto, "include-protobuf", true, "Include Protocol Buffer files (*.proto)")
+	cmd.Flags().BoolVar(&cfg.includeOpenAPI, "include-openapi", true, "Include OpenAPI/Swagger files")
+	cmd.Flags().BoolVar(&cfg.includeScraper, "include-scraper-markdown", true, "Include scraper markdown files")
 	cmd.Flags().IntVar(&cfg.limitElements, "limit", 0, "Limit number of elements to ingest (0 = no limit)")
 	cmd.Flags().BoolVar(&cfg.extractSymbols, "extract-symbols", true, "Extract code symbols (constants, functions, classes) for evidence-locked retrieval")
 
@@ -156,6 +162,12 @@ type ingestConfig struct {
 	includePy      bool
 	includeJava    bool
 	includeRust    bool
+	includePHP     bool
+	includeGraphQL bool
+	includeLua     bool
+	includeProto   bool
+	includeOpenAPI bool
+	includeScraper bool
 	limitElements  int
 	extractSymbols bool
 
@@ -955,8 +967,14 @@ func getEnabledLanguages(cfg *ingestConfig) map[string]bool {
 		"cypher":     true,
 		"csharp":     true,
 		"kotlin":     true,
-		"terraform":  true,
-		"makefile":   true,
+		"terraform":       true,
+		"makefile":        true,
+		"php":              cfg.includePHP,
+		"graphql":          cfg.includeGraphQL,
+		"lua":              cfg.includeLua,
+		"protobuf":         cfg.includeProto,
+		"openapi":          cfg.includeOpenAPI,
+		"scraper-markdown": cfg.includeScraper,
 	}
 }
 

--- a/internal/languages/README.md
+++ b/internal/languages/README.md
@@ -263,7 +263,22 @@ See existing specs for examples of the full schema.
 
 ### Step 6: Register in the Ingester
 
-The parser auto-registers in the parser registry via `init()`, but the ingester has a separate enabled-languages gate. Add a CLI flag and wire it into `getEnabledLanguages()` in `cmd/ingest-codebase/main.go`:
+The parser auto-registers in the parser registry via `init()`, but the ingester has a separate enabled-languages gate. You must register in **both** ingester implementations:
+
+**`internal/cli/ingest.go`** (shipped `mdemg` binary — this is what matters for releases):
+
+```go
+// In the ingestConfig struct:
+includeMyLang bool
+
+// In the cobra flag registration:
+cmd.Flags().BoolVar(&cfg.includeMyLang, "include-mylang", true, "Include MyLang files (*.ml)")
+
+// In getEnabledLanguages():
+"mylang": cfg.includeMyLang,
+```
+
+**`cmd/ingest-codebase/main.go`** (standalone dev tool):
 
 ```go
 // At the top with other flags:
@@ -280,7 +295,7 @@ All languages must use CLI flags (no hardcoded `true` entries). Without this ste
 After adding your parser:
 
 ```bash
-go build ./cmd/ingest-codebase/
+go build -o bin/mdemg ./cmd/mdemg
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

I realized today that #294 fixed the wrong ingestion binary, sorry about that. I didn't realize there were two and the one I fixed is not the one released via Homebrew. This PR applies the same fix from #294 but to the correct binary.

- Add 6 missing languages to `getEnabledLanguages()` in `internal/cli/ingest.go` (the shipped `mdemg` binary): PHP, GraphQL, Lua, Protobuf, OpenAPI, and scraper-markdown
- All 6 use CLI flags (no hardcoded `true` entries), matching the existing Java/Python/Rust/TS convention
- Update docs in `CONTRIBUTING.md` and `internal/languages/README.md` to reference both ingester implementations

## Motivation

#294 only fixed `cmd/ingest-codebase/main.go` (a standalone dev tool not included in releases). The shipped binary is built from `internal/cli/ingest.go`, which was never updated. goreleaser builds only `./cmd/mdemg`, so PHP and the other 5 languages were silently skipped.

## What changed

**`internal/cli/ingest.go`:**
- Added `includePHP`, `includeGraphQL`, `includeLua`, `includeProto`, `includeOpenAPI`, `includeScraper` fields to `ingestConfig`
- Registered 6 cobra flags (`--include-php`, `--include-graphql`, `--include-lua`, `--include-protobuf`, `--include-openapi`, `--include-scraper-markdown`), all defaulting to `true`
- Added all 6 to the `getEnabledLanguages()` map, wired to their flags

**`CONTRIBUTING.md` and `internal/languages/README.md`:**
- Updated "Register in the Ingester" step to reference **both** `internal/cli/ingest.go` (shipped binary) and `cmd/ingest-codebase/main.go` (dev tool)
- Updated build command to `go build -o bin/mdemg ./cmd/mdemg`

## Not in scope

- `cmd/ingest-codebase/main.go` already has these flags from PR #294. **This might be dead code** (not built by goreleaser, not shipped on any platform). If it is, I can remove it as part of this PR to avoid confusion in the future,  but I didn't want to do that without confirmation from @reh3376.
- Parser precedence issue (OpenAPI vs JSON, scraper-markdown vs Markdown) tracked in #312. Pre-existing, not introduced by this PR.

## Test plan

- [x] `go test ./...` passes
- [x] `go build -o bin/mdemg ./cmd/mdemg` succeeds (same build path as goreleaser)
- [x] `--include-php` visible in `mdemg ingest --help`
- [x] All 6 new flags visible in help output
- [x] Dry-run against two real Laravel codebases. (2,338 PHP elements extracted in one and 287 in the other)
- [x] `--include-php=false` correctly excludes all PHP elements
- [x] Codex review passed (flagged only the pre-existing precedence issue, now tracked in #312)
