### PR TITLE
fix(parser): MarkdownParser yields to ScraperMarkdownParser for .scraped.md

### DIFF
--- a/internal/languages/markdown_parser.go
+++ b/internal/languages/markdown_parser.go
@@ -23,6 +23,10 @@ func (p *MarkdownParser) Extensions() []string {
 
 func (p *MarkdownParser) CanParse(path string) bool {
 	pathLower := strings.ToLower(path)
+	// Skip scraped markdown - it has its own parser
+	if strings.HasSuffix(pathLower, ".scraped.md") {
+		return false
+	}
 	return strings.HasSuffix(pathLower, ".md") || strings.HasSuffix(pathLower, ".markdown")
 }
 


### PR DESCRIPTION
## Summary

Markdown parser now yields to scraper-markdown parser for `.scraped.md` files, fixing nondeterministic parser selection.

Partial fix for #312.

## Motivation

`GetParserForFile()` iterates a `map[string]LanguageParser`, and Go map iteration order is nondeterministic. A `.scraped.md` file matches both `ScraperMarkdownParser.CanParse()` and `MarkdownParser.CanParse()`. If Markdown wins the map race, scraper-specific extraction is lost and `--include-scraper-markdown` is bypassed.

## Approach

Applied the same "yield" pattern already used by `YAMLParser.CanParse()` (yaml_parser.go:31-42): `MarkdownParser.CanParse()` now returns `false` for `.scraped.md` files, letting the scraper-markdown parser handle them deterministically.

## Why only the Markdown fix?

Issue #312 also describes a JSON/OpenAPI precedence conflict, but that can't be fixed with the same approach. The OpenAPI parser (`internal/languages/openapi_parser.go`) uses YAML-specific regex patterns for symbol extraction. It correctly detects JSON-formatted OpenAPI specs, but produces zero symbols from them. Routing JSON OpenAPI files away from `JSONParser` would make things worse. The JSON/OpenAPI fix is blocked until `OpenAPIParser` supports JSON-formatted specs.

## Test plan

- [x] `go test ./internal/languages/... -v` -- all 28 UPTS parser tests pass (including markdown, scraper-markdown)
- [x] `go build -o bin/mdemg ./cmd/mdemg` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown file parsing to properly exclude scraped markdown files from being handled by the generic parser, ensuring more accurate file type processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->